### PR TITLE
Fix AVC format reading

### DIFF
--- a/Sources/ISO/H264+AVC.swift
+++ b/Sources/ISO/H264+AVC.swift
@@ -21,8 +21,7 @@ struct AVCFormatStream {
         var result:Data = Data()
         while (0 < buffer.bytesAvailable) {
             do {
-                buffer.position += 2
-                let length:Int = try Int(buffer.readUInt16())
+                let length:Int = try Int(buffer.readUInt32())
                 result.append(contentsOf: [0x00, 0x00, 0x00, 0x01])
                 result.append(try buffer.readBytes(length))
             } catch {


### PR DESCRIPTION
In AVC format, NAL Units are accompanied with its length in 4 bytes, big endian.
Skipping first 2 bytes is invalid, because there may be valid non-zero bytes.
In order to convert AVC format to Annex-B byte stream, the program must read all 4 bytes as length and read that bytes as NAL unit.