### PR TITLE
Move the size calculation to UI thread

### DIFF
--- a/Platforms/iOS/ScreenCaptureSession.swift
+++ b/Platforms/iOS/ScreenCaptureSession.swift
@@ -84,6 +84,14 @@ open class ScreenCaptureSession: NSObject {
         guard semaphore.wait(timeout: DispatchTime.now()) == .success else {
             return
         }
+        
+        if let shared = self.shared {
+            size = shared.delegate!.window!!.bounds.size
+        }
+        if let viewToCapture = self.viewToCapture {
+            size = viewToCapture.bounds.size
+        }
+        
         lockQueue.async {
             autoreleasepool {
                 self.onScreenProcess(displayLink)
@@ -95,12 +103,6 @@ open class ScreenCaptureSession: NSObject {
     open func onScreenProcess(_ displayLink:CADisplayLink) {
         var pixelBuffer:CVPixelBuffer?
         
-        if let shared = self.shared {
-            size = shared.delegate!.window!!.bounds.size
-        }
-        if let viewToCapture = self.viewToCapture {
-            size = viewToCapture.bounds.size
-        }
         CVPixelBufferPoolCreatePixelBuffer(nil, pixelBufferPool, &pixelBuffer)
         CVPixelBufferLockBaseAddress(pixelBuffer!, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)))
         UIGraphicsBeginImageContextWithOptions(size, false, scale)


### PR DESCRIPTION
The display link callback happens on the UI Thread (currently), so putting it here is an acceptable fix.