### PR TITLE
Remove extraneous space from auth command url.

### DIFF
--- a/Sources/RTMP/RTMPConnection.swift
+++ b/Sources/RTMP/RTMPConnection.swift
@@ -131,7 +131,7 @@ open class RTMPConnection: EventDispatcher {
 
         let query: String = String(description[description.index(index, offsetBy: 1)...])
         let challenge: String = String(format: "%08x", arc4random())
-        let dictionary: [String: String] = URL(string: "http: //localhost?" + query)!.dictionaryFromQuery()
+        let dictionary: [String: String] = URL(string: "http://localhost?" + query)!.dictionaryFromQuery()
 
         var response: String = MD5.base64("\(url.user!)\(dictionary["salt"]!)\(url.password!)")
         if let opaque: String = dictionary["opaque"] {


### PR DESCRIPTION
Because of the space in this url string the URL construction always fails and the ! operator results in a crash.