### PR TITLE
fixed autofocus after focussing point of interest

### DIFF
--- a/Sources/Media/VideoIOComponent.swift
+++ b/Sources/Media/VideoIOComponent.swift
@@ -111,7 +111,7 @@ final class VideoIOComponent: IOComponent {
             do {
                 try device.lockForConfiguration()
                 device.focusPointOfInterest = point
-                device.focusMode = .autoFocus
+                device.focusMode = .continuousAutoFocus
                 device.unlockForConfiguration()
             } catch let error as NSError {
                 logger.error("while locking device for focusPointOfInterest: \(error)")
@@ -130,7 +130,7 @@ final class VideoIOComponent: IOComponent {
             do {
                 try device.lockForConfiguration()
                 device.exposurePointOfInterest = point
-                device.exposureMode = .autoExpose
+                device.exposureMode = .continuousAutoExposure
                 device.unlockForConfiguration()
             } catch let error as NSError {
                 logger.error("while locking device for exposurePointOfInterest: \(error)")


### PR DESCRIPTION
After using setPointOfInterest to focus, autofocus is not working anymore. 
by changing the focus- and exposuremode to continuousAuto it now works just like native ios camera.

It will focus at a selected point, but when you move the camera, autofocus takes over. 