### PR TITLE
Async set NetStream settings

### DIFF
--- a/Sources/Net/NetStream.swift
+++ b/Sources/Net/NetStream.swift
@@ -74,7 +74,7 @@ open class NetStream: NSObject {
             return  audioSettings
         }
         set {
-            lockQueue.sync {
+            lockQueue.async {
                 self.mixer.audioIO.encoder.setValuesForKeys(newValue)
             }
         }
@@ -89,7 +89,7 @@ open class NetStream: NSObject {
             return videoSettings
         }
         set {
-            lockQueue.sync {
+            lockQueue.async {
                 self.mixer.videoIO.encoder.setValuesForKeys(newValue)
             }
         }
@@ -104,7 +104,7 @@ open class NetStream: NSObject {
             return captureSettings
         }
         set {
-            lockQueue.sync {
+            lockQueue.async {
                 self.mixer.setValuesForKeys(newValue)
             }
         }
@@ -119,7 +119,7 @@ open class NetStream: NSObject {
             return recorderSettings
         }
         set {
-            lockQueue.sync {
+            lockQueue.async {
                 self.mixer.recorder.outputSettings = newValue
             }
         }


### PR DESCRIPTION
In commit b3d6698, various settings in NetStream were changed to be updated synchronously. However, this is causing deadlock when video settings are updated (e.g. in ``viewWillAppear()``) when returning back from another view controller. This commit changes ``sync`` back to ``async`` to avoid deadlock.