### PR TITLE
Remove "publishing" restriction for appending sample buffer

### DIFF
--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -546,13 +546,6 @@ open class RTMPStream: NetStream {
         }
     }
 
-    open override func appendSampleBuffer(_ sampleBuffer: CMSampleBuffer, withType: CMSampleBufferType, options: [NSObject: AnyObject]? = nil) {
-        guard readyState == .publishing else {
-            return
-        }
-        super.appendSampleBuffer(sampleBuffer, withType: withType, options: options)
-    }
-
     open func appendFile(_ file: URL, completionHandler: MP4Sampler.Handler? = nil) {
         lockQueue.async {
             if self.sampler == nil {


### PR DESCRIPTION
In the previous implementation, ``AppendSampleBuffer()`` in RTMPStream will not append sample buffer unless the stream is already publishing. But this will prevent stream from drawing on view unless the source is the built-in camera, configured via ``AttachCamera()``. ``AttachCamera()`` is able to draw on view when stream is not publishing, which creates the "preview" experience, as it directly invokes ``AppendSampleBuffer()`` in NetStream.

This commit removes the overridden ``AppendSampleBuffer()`` in RTMPStream, which allows callers to invoke ``AppendSampleBuffer()`` in NetStream directly. This will enable sources other than built-in camera to gain "preview" experience as well.