### PR TITLE
Record content locally without streaming to remote server

### DIFF
--- a/HaishinKit.xcodeproj/project.pbxproj
+++ b/HaishinKit.xcodeproj/project.pbxproj
@@ -338,6 +338,7 @@
 		29F6F4861DFB862400920A3A /* RTMPHandshake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F6F4841DFB83E200920A3A /* RTMPHandshake.swift */; };
 		29FB94311E1BECCA005DE4DF /* SoundSpliter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FB94301E1BECCA005DE4DF /* SoundSpliter.swift */; };
 		29FB94321E1BF507005DE4DF /* SoundSpliter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FB94301E1BECCA005DE4DF /* SoundSpliter.swift */; };
+		5584FF83206BC0C200D6CF31 /* LocalStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5584FF82206BC0C200D6CF31 /* LocalStream.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -629,6 +630,7 @@
 		29F04FF21F3388B000172706 /* HaishinKit.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = HaishinKit.podspec; sourceTree = "<group>"; };
 		29F6F4841DFB83E200920A3A /* RTMPHandshake.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RTMPHandshake.swift; path = Sources/RTMP/RTMPHandshake.swift; sourceTree = SOURCE_ROOT; };
 		29FB94301E1BECCA005DE4DF /* SoundSpliter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SoundSpliter.swift; path = Sources/Media/SoundSpliter.swift; sourceTree = SOURCE_ROOT; };
+		5584FF82206BC0C200D6CF31 /* LocalStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LocalStream.swift; path = Local/LocalStream.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -865,6 +867,7 @@
 				295891081EEB8B1D00CE51E1 /* FLV */,
 				2960CD3E1CC0C7C900B4E877 /* HTTP */,
 				295FEFA91C38236900271E90 /* ISO */,
+				5584FF81206BC07400D6CF31 /* Local */,
 				29BDE0BD1C65BC2400D6A768 /* Media */,
 				297C16881CC5382600117ADF /* Net */,
 				29C0E0591C2EB00A009DD8E8 /* RTMP */,
@@ -1150,6 +1153,14 @@
 				29D8067F204828D000F4504D /* VTSession+Extension.swift */,
 			);
 			name = Extension;
+			sourceTree = "<group>";
+		};
+		5584FF81206BC07400D6CF31 /* Local */ = {
+			isa = PBXGroup;
+			children = (
+				5584FF82206BC0C200D6CF31 /* LocalStream.swift */,
+			);
+			name = Local;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1683,6 +1694,7 @@
 				29B876851CD70AE800FC07DA /* NALUnit.swift in Sources */,
 				29EA87ED1E79A3E30043A5F8 /* CVPixelBuffer+Extension.swift in Sources */,
 				2958912A1EEB8F1D00CE51E1 /* FLVSoundSize.swift in Sources */,
+				5584FF83206BC0C200D6CF31 /* LocalStream.swift in Sources */,
 				29EA87DC1E79A0460043A5F8 /* Data+Extension.swift in Sources */,
 				29B876BD1CD70B3900FC07DA /* CRC32.swift in Sources */,
 				29EA87E61E79A2780043A5F8 /* CMAudioFormatDescription+Extension.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -221,6 +221,20 @@ httpService.addHTTPStream(httpStream)
 view.addSubview(lfView)
 ```
 
+## Local Usage
+Record content locally without streaming to remote server.
+```swift
+var localStream: LocalStream = LocalStream()
+localStream.attachCamera(DeviceUtil.device(withPosition: .back))
+localStream.attachAudio(AVCaptureDevice.defaultDevice(withMediaType: AVMediaTypeAudio))
+local.Stream.record("hello")
+
+var lfView: LFView = LFView(frame: view:bounds)
+lfView.attachStream(localStream)
+
+view.addSubview(lfView)
+```
+
 ## FAQ
 ### How can I run example project?
 Please hit `carthage update` command. HaishinKit needs Logboard module via Carthage.

--- a/Sources/Local/LocalStream.swift
+++ b/Sources/Local/LocalStream.swift
@@ -1,0 +1,92 @@
+open class LocalStream: NetStream {
+    var resourceName: String?
+
+    open private(set) var recording: Bool = false {
+        didSet {
+            guard oldValue != recording else {
+                return
+            }
+
+            if oldValue {
+                // was recording
+                #if os(iOS)
+                    mixer.videoIO.screen?.stopRunning()
+                #endif
+                mixer.audioIO.encoder.stopRunning()
+                mixer.videoIO.encoder.stopRunning()
+                mixer.recorder.stopRunning()
+            }
+
+            if recording {
+                #if os(iOS)
+                    mixer.videoIO.screen?.startRunning()
+                #endif
+                mixer.startRunning()
+                mixer.audioIO.encoder.startRunning()
+                mixer.videoIO.encoder.startRunning()
+                mixer.recorder.fileName = resourceName
+                mixer.recorder.startRunning()
+            }
+        }
+    }
+
+    var paused: Bool = false
+
+    deinit {
+        mixer.stopRunning()
+    }
+
+    open func record(_ name: String?) {
+        lockQueue.async {
+            guard let name: String = name else {
+                if self.recording {
+                    self.recording = false
+                }
+                return
+            }
+
+            self.resourceName = name
+            self.recording = true
+        }
+    }
+
+    open func close() {
+        if !recording {
+            return
+        }
+        record(nil)
+        lockQueue.sync {
+            self.recording = false
+        }
+    }
+
+    open func pause() {
+        lockQueue.async {
+            self.paused = true
+            if self.recording {
+                self.mixer.audioIO.encoder.muted = true
+                self.mixer.videoIO.encoder.muted = true
+            }
+        }
+    }
+
+    open func resume() {
+        lockQueue.async {
+            self.paused = false
+            if self.recording {
+                self.mixer.audioIO.encoder.muted = false
+                self.mixer.videoIO.encoder.muted = false
+            }
+        }
+    }
+
+    open func togglePause() {
+        lockQueue.async {
+            if self.recording {
+                self.paused = !self.paused
+                self.mixer.audioIO.encoder.muted = self.paused
+                self.mixer.videoIO.encoder.muted = self.paused
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implement LocalStream, which inherits NetStream, to support recording content locally without streaming to remote server.

Obviously this feature will not be useful when source is the built-in camera, as the built-in camera app already offers recording functionality. But sources other than the built-in camera, which sample buffers are appended directly via ``appendSampleBuffer()``, can still benefit from this.