### PR TITLE
Fix Swift 4.1 'Overlapping Accesses' Error

### DIFF
--- a/Sources/RTMP/RTMPSharedObject.swift
+++ b/Sources/RTMP/RTMPSharedObject.swift
@@ -51,22 +51,24 @@ struct RTMPSharedObjectEvent {
     }
 
     func serialize(_ serializer: inout AMFSerializer) {
-        serializer.writeUInt8(type.rawValue)
+        var serializerCopy = serializer
+        serializerCopy.writeUInt8(type.rawValue)
         guard let name: String = name else {
-            serializer.writeUInt32(0)
+            serializerCopy.writeUInt32(0)
             return
         }
-        let position: Int = serializer.position
-        serializer
+        let position: Int = serializerCopy.position
+        serializerCopy
             .writeUInt32(0)
             .writeUInt16(UInt16(name.utf8.count))
             .writeUTF8Bytes(name)
             .serialize(data)
-        let size: Int = serializer.position - position
-        serializer.position = position
-        serializer.writeUInt32(UInt32(size) - 4)
-        let length = serializer.length
-        serializer.position = length
+        let size: Int = serializerCopy.position - position
+        serializerCopy.position = position
+        serializerCopy.writeUInt32(UInt32(size) - 4)
+        let length = serializerCopy.length
+        serializerCopy.position = length
+        serializer = serializerCopy
     }
 }
 


### PR DESCRIPTION
I updated Xcode to 9.3, Swift 4.1 and ran into this new error on build. Creating a local copy like the error and these [Apple Docs](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/MemorySafety.html) suggested fixes the error. 


<img width="818" alt="screen shot 2018-04-04 at 11 04 51 am" src="https://user-images.githubusercontent.com/2192108/38324597-c10abf44-380e-11e8-9a67-8e016c357e7c.png">