### PR TITLE
resolve shogo4405/HaishinKit.swift#413

### DIFF
--- a/Sources/ISO/TSWriter.swift
+++ b/Sources/ISO/TSWriter.swift
@@ -16,11 +16,21 @@ class TSWriter {
         if sequence <= TSWriter.defaultSegmentMaxCount {
             m3u8.mediaSequence = 0
             m3u8.mediaList = files
+            for mediaItem in m3u8.mediaList {
+                if mediaItem.duration > m3u8.targetDuration {
+                    m3u8.targetDuration = mediaItem.duration + 1
+                }
+            }
             return m3u8.description
         }
         let startIndex = max(0, files.count - TSWriter.defaultSegmentCount)
         m3u8.mediaSequence = sequence - TSWriter.defaultSegmentMaxCount
         m3u8.mediaList = Array(files[startIndex..<files.count])
+        for mediaItem in m3u8.mediaList {
+            if mediaItem.duration > m3u8.targetDuration {
+                m3u8.targetDuration = mediaItem.duration + 1
+            }
+        }
         return m3u8.description
     }
     var lockQueue = DispatchQueue(label: "com.haishinkit.HaishinKit.TSWriter.lock")


### PR DESCRIPTION
Using HLS with TSWriter, I found the "EXT-X-TARGETDURATION" is incorrect sometime at iPhone device.

```
#EXTM3U
#EXT-X-VERSION: 3
#EXT-X-MEDIA-SEQUENCE: 0
#EXT-X-TARGETDURATION: 6
#EXTINF: 6.00054620800074,
280238.ts
#EXTINF: 6.00050887500402,
280244.ts
#EXTINF: 6.00048975000391,
```

According to https://tools.ietf.org/html/draft-pantos-http-live-streaming-08#section-3.4.2:

```
The EXT-X-TARGETDURATION tag specifies the maximum media segment
   duration.  The EXTINF duration of each media segment in the Playlist
   file MUST be less than or equal to the target duration.  This tag
   MUST appear once in the Playlist file.
```