### PR TITLE
use UIInterfaceOrientation instead of UIDeviceOrientation.

### DIFF
--- a/HaishinKit.xcodeproj/project.pbxproj
+++ b/HaishinKit.xcodeproj/project.pbxproj
@@ -2259,7 +2259,7 @@
 		2945CBD41B4BE66000104112 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -2291,7 +2291,7 @@
 		2945CBD51B4BE66000104112 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;

--- a/Platforms/iOS/DeviceUtil+Extenstion.swift
+++ b/Platforms/iOS/DeviceUtil+Extenstion.swift
@@ -23,4 +23,19 @@ extension DeviceUtil {
             return nil
         }
     }
+    
+    static public func videoOrientation(by orientation: UIInterfaceOrientation) -> AVCaptureVideoOrientation? {
+        switch orientation {
+        case .portrait:
+            return .portrait
+        case .portraitUpsideDown:
+            return .portraitUpsideDown
+        case .landscapeLeft:
+            return .landscapeLeft
+        case .landscapeRight:
+            return .landscapeRight
+        default:
+            return nil
+        }
+    }
 }

--- a/Sources/Media/VideoIOComponent.swift
+++ b/Sources/Media/VideoIOComponent.swift
@@ -215,9 +215,9 @@ final class VideoIOComponent: IOComponent {
         encoder.lockQueue = lockQueue
         decoder.delegate = self
         #if os(iOS)
-            if let orientation: AVCaptureVideoOrientation = DeviceUtil.videoOrientation(by: UIDevice.current.orientation) {
+            if let orientation: AVCaptureVideoOrientation = DeviceUtil.videoOrientation(by: UIApplication.shared.statusBarOrientation) {
                 self.orientation = orientation
-                }
+            }
         #endif
     }
 

--- a/Sources/Net/NetStream.swift
+++ b/Sources/Net/NetStream.swift
@@ -63,9 +63,9 @@ open class NetStream: NSObject {
                 return
             }
             if syncOrientation {
-                NotificationCenter.default.addObserver(self, selector: #selector(on), name: .UIDeviceOrientationDidChange, object: nil)
+                NotificationCenter.default.addObserver(self, selector: #selector(on), name: .UIApplicationDidChangeStatusBarOrientation, object: nil)
             } else {
-                NotificationCenter.default.removeObserver(self, name: .UIDeviceOrientationDidChange, object: nil)
+                NotificationCenter.default.removeObserver(self, name: .UIApplicationDidChangeStatusBarOrientation, object: nil)
             }
         }
     }
@@ -190,8 +190,8 @@ open class NetStream: NSObject {
     }
 
     #if os(iOS)
-    @objc private func on(uiDeviceOrientationDidChange: Notification) {
-        if let orientation: AVCaptureVideoOrientation = DeviceUtil.videoOrientation(by: uiDeviceOrientationDidChange) {
+    @objc private func on(uiInterfaceOrientationDidChange: Notification) {
+        if let orientation: AVCaptureVideoOrientation = DeviceUtil.videoOrientation(by: UIApplication.shared.statusBarOrientation) {
             self.orientation = orientation
         }
     }


### PR DESCRIPTION
Hi, this library is gorgeous. That's exactly what we want.

We introduced this Kit, and found something to improve about orientation.

We think GLHKView should be autorotated by UIInterfaceOrientation, not UIDeviceOrientation.

When I want to restrict streaming orientation with UIViewController's interface orientation, picture went wrong both on streaming device & viewers, especially in viewers side.

---

Here is how to reproduce this problem.

```
Xcode: Version 9.4.1 (9F2000)
iOS: Version 11.4.1 (Latest)
Project: HaishinKit 0.9.1
Target: Example iOS
```

Add `supportedInterfaceOrientations` to LiveViewController in target **Example iOS**

```swift
override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
    return .landscape
}
```

and change screen ratio to landscape (height < width) at viewDidLoad.

```swift
rtmpStream.videoSettings = [
    "width": 1280,
    "height": 720
]
```

Then start streaming, picture will rotate with UIDeviceOrientation, instead of UIInterfaceOrientation.

When you hold your device in portrait orientation, picture in GLHKView and stream went wrong like this.

![screen shot 1](https://user-images.githubusercontent.com/2227383/43627487-8ee8acb0-9731-11e8-9325-e145fe5bf762.png)

![screen shot 2](https://user-images.githubusercontent.com/2227383/43627508-a1bed080-9731-11e8-9ad7-d053c7bed160.png)

Especially in viewer, picture is very zoomed.

---

To figure out this problem, I have fixed some codes relate interface orientation.

But it won't build without unchecking `APPLICATION_EXTENSION_API_ONLY` in `Development Info`. (This option does'nt allow to use `UIApplication.shared.statusBarOrientation`)

![screen shot 3](https://user-images.githubusercontent.com/2227383/43627515-a8938c66-9731-11e8-9a71-daab82c9a731.png)

Further more info, please check PR.