### PR TITLE
setting RTMP composition time to match delta, fixes streaming to VLC.

### DIFF
--- a/Sources/RTMP/RTMPMuxer.swift
+++ b/Sources/RTMP/RTMPMuxer.swift
@@ -61,15 +61,13 @@ extension RTMPMuxer: VideoEncoderDelegate {
 
     func sampleOutput(video sampleBuffer: CMSampleBuffer) {
         let keyframe: Bool = !sampleBuffer.dependsOnOthers
-        var compositionTime: Int32 = 0
         let presentationTimeStamp: CMTime = sampleBuffer.presentationTimeStamp
         var decodeTimeStamp: CMTime = sampleBuffer.decodeTimeStamp
         if decodeTimeStamp == kCMTimeInvalid {
             decodeTimeStamp = presentationTimeStamp
-        } else {
-            compositionTime = Int32((decodeTimeStamp.seconds - decodeTimeStamp.seconds) * 1000)
         }
         let delta: Double = (videoTimestamp == kCMTimeZero ? 0 : decodeTimeStamp.seconds - videoTimestamp.seconds) * 1000
+        let compositionTime = Int32(delta)
         guard let data = sampleBuffer.dataBuffer?.data, 0 <= delta else {
             return
         }


### PR DESCRIPTION
This fixes https://github.com/shogo4405/HaishinKit.swift/issues/118 