### PR TITLE
username and password is no longer inadvertently included in `tcUrl`

### DIFF
--- a/Sources/Extension/URL+Extension.swift
+++ b/Sources/Extension/URL+Extension.swift
@@ -2,17 +2,10 @@ import Foundation
 
 extension URL {
     var absoluteWithoutAuthenticationString: String {
-        var target: String = ""
-        if let user = user {
-            target += user
-        }
-        if let password: String = password {
-            target += ": " + password
-        }
-        if target != "" {
-            target += "@"
-        }
-        return absoluteString.replacingOccurrences(of: target, with: "")
+        guard var components = URLComponents(string: absoluteString) else { return absoluteString }
+        components.password = nil
+        components.user = nil
+        return components.url?.absoluteString ?? absoluteString
     }
 
     var absoluteWithoutQueryString: String {


### PR DESCRIPTION
Fixes #472 - username and password is no longer included in `tcUrl`.  URLComponents is used instead of string replacement in URL extension's `absoluteWithoutAuthenticationString` computed property.  Please see #472 for a description of the cause of the bug.