### PR TITLE
fix #366 localRecord is not worked by default

### DIFF
--- a/Sources/Media/AVRecorder.swift
+++ b/Sources/Media/AVRecorder.swift
@@ -30,6 +30,7 @@ open class AVRecorder: NSObject {
     open var writer: AVAssetWriter?
     open var fileName: String?
     open weak var delegate: AVRecorderDelegate?
+    private var defaultDelegate = DefaultAVRecorderDelegate()
     open var writerInputs: [AVMediaType: AVAssetWriterInput] = [:]
     open var outputSettings: [AVMediaType: [String: Any]] = AVRecorder.defaultOutputSettings
     open var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
@@ -46,7 +47,7 @@ open class AVRecorder: NSObject {
 
     override public init() {
         super.init()
-        delegate = DefaultAVRecorderDelegate()
+        delegate = defaultDelegate
     }
 
     final func appendSampleBuffer(_ sampleBuffer: CMSampleBuffer, mediaType: AVMediaType) {

--- a/Sources/Media/AVRecorder.swift
+++ b/Sources/Media/AVRecorder.swift
@@ -30,7 +30,7 @@ open class AVRecorder: NSObject {
     open var writer: AVAssetWriter?
     open var fileName: String?
     open weak var delegate: AVRecorderDelegate?
-    private var defaultDelegate = DefaultAVRecorderDelegate()
+    private let defaultDelegate = DefaultAVRecorderDelegate()
     open var writerInputs: [AVMediaType: AVAssetWriterInput] = [:]
     open var outputSettings: [AVMediaType: [String: Any]] = AVRecorder.defaultOutputSettings
     open var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?


### PR DESCRIPTION
Because property delegate is declared with weak attribute.
```swift
open weak var delegate: AVMixerRecorderDelegate?
```

Solve this Issue #366 