### PR TITLE
drawable orientation to match stream when created

### DIFF
--- a/Sources/Media/VideoIOComponent.swift
+++ b/Sources/Media/VideoIOComponent.swift
@@ -27,7 +27,11 @@ final class VideoIOComponent: IOComponent {
             }
         }
     }
-    var drawable: NetStreamDrawable?
+    var drawable: NetStreamDrawable? = nil {
+        didSet {
+            drawable?.orientation = orientation
+        }
+    }
     var formatDescription: CMVideoFormatDescription? {
         didSet {
             decoder.formatDescription = formatDescription


### PR DESCRIPTION
Resolves #505 

The VideoIOComponent.orientation value can be different to the `drawable.orientation` value. This happens when RTMPStream.orientation is set and the drawable is nil.

With this change, after the drawable is created, its orientation is set to match the RTMPStream orientation.