### PR TITLE
static variable to set default orientation & always update drawable

### DIFF
--- a/Sources/Media/VideoIOComponent.swift
+++ b/Sources/Media/VideoIOComponent.swift
@@ -112,6 +112,7 @@ final class VideoIOComponent: IOComponent {
 
     var orientation: AVCaptureVideoOrientation = .portrait {
         didSet {
+            drawable?.orientation = orientation
             guard orientation != oldValue else {
                 return
             }
@@ -121,7 +122,6 @@ final class VideoIOComponent: IOComponent {
                     setTorchMode(.on)
                 }
             }
-            drawable?.orientation = orientation
         }
     }
 
@@ -274,6 +274,8 @@ final class VideoIOComponent: IOComponent {
         #if os(iOS)
         if let orientation: AVCaptureVideoOrientation = DeviceUtil.videoOrientation(by: UIDevice.current.orientation) {
             self.orientation = orientation
+        } else if let defaultOrientation = RTMPStream.defaultOrientation {
+            self.orientation = defaultOrientation
         }
         #endif
     }

--- a/Sources/Net/NetStream.swift
+++ b/Sources/Net/NetStream.swift
@@ -175,11 +175,11 @@ open class NetStream: NSObject {
         }
     }
 
-    open func registerEffect(video effect: VisualEffect) -> Bool {
+    @discardableResult open func registerEffect(video effect: VisualEffect) -> Bool {
         return mixer.videoIO.registerEffect(effect)
     }
 
-    open func unregisterEffect(video effect: VisualEffect) -> Bool {
+    @discardableResult open func unregisterEffect(video effect: VisualEffect) -> Bool {
         return mixer.videoIO.unregisterEffect(effect)
     }
 

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -206,6 +206,7 @@ open class RTMPStream: NetStream {
     static let defaultID: UInt32 = 0
     public static let defaultAudioBitrate: UInt32 = AudioConverter.defaultBitrate
     public static let defaultVideoBitrate: UInt32 = H264Encoder.defaultBitrate
+    public static var defaultOrientation: AVCaptureVideoOrientation? = nil
     open weak var delegate: RTMPStreamDelegate?
     open internal(set) var info = RTMPStreamInfo()
     open private(set) var objectEncoding: UInt8 = RTMPConnection.defaultObjectEncoding


### PR DESCRIPTION
Follow up to PR #506.

This fixes #505.

The drawable's orientation was still getting out of sync. With this PR, the initial orientation can be set using a static variable. It was also necessary to always update the drawable's orientation when orientation is set.

I don't know what was causing the orientations to get out of sync but these changes fix it for me.