### PR TITLE
Add the ability to disable the iPhone camera stabilization

### DIFF
--- a/Sources/Media/AVMixer.swift
+++ b/Sources/Media/AVMixer.swift
@@ -35,6 +35,11 @@ public class AVMixer: NSObject {
         get { return videoIO.continuousAutofocus }
         set { videoIO.continuousAutofocus = newValue }
     }
+    
+    @objc var stabilization: Bool {
+        get { return videoIO.stabilization }
+        set { videoIO.stabilization = newValue }
+    }
 
     @objc var sessionPreset: AVCaptureSession.Preset = .default {
         didSet {

--- a/Sources/Media/VideoIOComponent.swift
+++ b/Sources/Media/VideoIOComponent.swift
@@ -123,6 +123,9 @@ final class VideoIOComponent: IOComponent {
                 if torch {
                     setTorchMode(.on)
                 }
+                if !stabilization {
+                    connection.preferredVideoStabilizationMode = .off
+                }
             }
         }
     }
@@ -212,6 +215,19 @@ final class VideoIOComponent: IOComponent {
                 device.unlockForConfiguration()
             } catch let error as NSError {
                 logger.error("while locking device for autoexpose: \(error)")
+            }
+        }
+    }
+    
+    var stabilization: Bool = true {
+        didSet {
+            guard stabilization != oldValue else {
+                return
+            }
+            if !newValue {
+                for connection in output.connections {
+                    connection.preferredVideoStabilizationMode = .off
+                }
             }
         }
     }
@@ -309,6 +325,11 @@ final class VideoIOComponent: IOComponent {
         mixer.session.addOutput(output)
         for connection in output.connections where connection.isVideoOrientationSupported {
             connection.videoOrientation = orientation
+        }
+        if !stabilization {
+            for connection in output.connections {
+                connection.preferredVideoStabilizationMode = .off
+            }
         }
         output.setSampleBufferDelegate(self, queue: lockQueue)
 

--- a/Sources/Media/VideoIOComponent.swift
+++ b/Sources/Media/VideoIOComponent.swift
@@ -224,7 +224,7 @@ final class VideoIOComponent: IOComponent {
             guard stabilization != oldValue else {
                 return
             }
-            if !newValue {
+            if !stabilization {
                 for connection in output.connections {
                     connection.preferredVideoStabilizationMode = .off
                 }


### PR DESCRIPTION
_Sorry about #512, this one should compile without any error._

There are many reports all over the Internet saying that the internal iPhone camera stabilization system is jamming external ones, for example, it acts against a gimbal stabilization method.
I'd like to use my app with a gimbal such as this one: https://www.dji.com/uk/osmo-mobile-2 but currently the results are shaky because of iOS stabilization behaviour.
Here is a PR to give the possibility to deactivate it within HaishinKit.swift.
Usage:
```
        rtmpStream.captureSettings = [
            "sessionPreset": AVCaptureSession.Preset.hd1280x720.rawValue,
            "continuousAutofocus": true,
            "continuousExposure": true,
            "stabilization": false
        ]