### PR TITLE
fix error when run in xcode10.2

### DIFF
--- a/Sources/FLV/FLVReader.swift
+++ b/Sources/FLV/FLVReader.swift
@@ -30,7 +30,7 @@ extension FLVReader: IteratorProtocol {
         guard let fileHandle: FileHandle = fileHandle else {
             return nil
         }
-        let tag: FLVTag!
+        var tag: FLVTag!
         fileHandle.seek(toFileOffset: currentOffSet)
         let data: Data = fileHandle.readData(ofLength: FLVReader.headerSize)
         guard !data.isEmpty else {


### PR DESCRIPTION
Apple released XCode 10.2 this morning.

You will see the error below in file `FLVReader.swift` when you build project with XCode 10.2.
`Mutating method 'readData' may not be used on immutable value 'tag'`
