### PR TITLE
Make RTMPConnection be deallocated on close()

### DIFF
--- a/Sources/RTMP/RTMPConnection.swift
+++ b/Sources/RTMP/RTMPConnection.swift
@@ -295,6 +295,7 @@ open class RTMPConnection: EventDispatcher {
 
     func close(isDisconnected: Bool) {
         guard connected || isDisconnected else {
+            timer = nil
             return
         }
         if !isDisconnected {

--- a/Tests/RTMP/RTMPConnectionTests.swift
+++ b/Tests/RTMP/RTMPConnectionTests.swift
@@ -14,4 +14,15 @@ final class RTMPConnectionTests: XCTestCase {
         stream.publish("live")
         sleep(10000)
     }
+
+    func testReleaseWhenClose() {
+        weak var weakConnection: RTMPConnection?
+        _ = {
+            let connection = RTMPConnection()
+            connection.connect("rtmp://localhost:1935/live")
+            connection.close()
+            weakConnection = connection
+        }()
+        XCTAssertNil(weakConnection)
+    }
 }


### PR DESCRIPTION
`timer` instance holds the `RTMPConnection` instance so it won't be deallocated after `close()` gets called.