### PR TITLE
Make RTMPStream be deallocated on close() when the readyState is .initialized

### DIFF
--- a/HaishinKit.xcodeproj/project.pbxproj
+++ b/HaishinKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		035AFA042263868E009DD0BB /* RTMPStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035AFA032263868E009DD0BB /* RTMPStreamTests.swift */; };
 		2901A4EE1D437170002BBD23 /* DisplayLinkedQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2901A4ED1D437170002BBD23 /* DisplayLinkedQueue.swift */; };
 		2901A4EF1D437662002BBD23 /* DisplayLinkedQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2901A4ED1D437170002BBD23 /* DisplayLinkedQueue.swift */; };
 		290686031DFDB7A7008EB7ED /* RTMPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290686021DFDB7A6008EB7ED /* RTMPConnectionTests.swift */; };
@@ -445,6 +446,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		035AFA032263868E009DD0BB /* RTMPStreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RTMPStreamTests.swift; sourceTree = "<group>"; };
 		2901A4ED1D437170002BBD23 /* DisplayLinkedQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayLinkedQueue.swift; sourceTree = "<group>"; };
 		290686021DFDB7A6008EB7ED /* RTMPConnectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RTMPConnectionTests.swift; sourceTree = "<group>"; };
 		290686041DFDC19B008EB7ED /* SampleVideo_360x240_5mb-base.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SampleVideo_360x240_5mb-base.mp4"; sourceTree = "<group>"; };
@@ -752,6 +754,7 @@
 				290686021DFDB7A6008EB7ED /* RTMPConnectionTests.swift */,
 				2976077E20A89FBB00DCF24F /* RTMPMessageTests.swift */,
 				294637A31EC8961C008EEC71 /* RTMPReaderTests.swift */,
+				035AFA032263868E009DD0BB /* RTMPStreamTests.swift */,
 			);
 			path = RTMP;
 			sourceTree = "<group>";
@@ -1731,6 +1734,7 @@
 				290EA8A11DFB61B100053022 /* RTMPChunkTests.swift in Sources */,
 				290EA89F1DFB61B100053022 /* AMF0SerializerTests.swift in Sources */,
 				290EA8AA1DFB61E700053022 /* CRC32Tests.swift in Sources */,
+				035AFA042263868E009DD0BB /* RTMPStreamTests.swift in Sources */,
 				290686031DFDB7A7008EB7ED /* RTMPConnectionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -276,6 +276,7 @@ open class RTMPStream: NetStream {
             }
         }
     }
+    private var isBeingClosed: Bool = false
 
     var audioTimestamp: Double = 0
     var videoTimestamp: Double = 0
@@ -361,7 +362,7 @@ open class RTMPStream: NetStream {
                 return
             }
 
-            while self.readyState == .initialized {
+            while self.readyState == .initialized && !self.isBeingClosed {
                 usleep(100)
             }
 
@@ -425,7 +426,7 @@ open class RTMPStream: NetStream {
                 return
             }
 
-            while self.readyState == .initialized {
+            while self.readyState == .initialized && !self.isBeingClosed {
                 usleep(100)
             }
 
@@ -460,9 +461,10 @@ open class RTMPStream: NetStream {
     }
 
     open func close() {
-        if readyState == .closed || readyState == .initialized {
+        if readyState == .closed {
             return
         }
+        isBeingClosed = true
         play()
         publish(nil)
         lockQueue.sync {
@@ -478,6 +480,7 @@ open class RTMPStream: NetStream {
                     commandObject: nil,
                     arguments: [self.id]
             )), locked: nil)
+            self.isBeingClosed = false
         }
     }
 

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -469,7 +469,7 @@ open class RTMPStream: NetStream {
         publish(nil)
         lockQueue.sync {
             self.readyState = .closed
-            self.rtmpConnection.socket.doOutput(chunk: RTMPChunk(
+            self.rtmpConnection.socket?.doOutput(chunk: RTMPChunk(
                 type: .zero,
                 streamId: RTMPChunk.StreamID.command.rawValue,
                 message: RTMPCommandMessage(

--- a/Tests/RTMP/RTMPStreamTests.swift
+++ b/Tests/RTMP/RTMPStreamTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import XCTest
+
+@testable import HaishinKit
+
+final class RTMPStreamTests: XCTestCase {
+    func testCloseRelease() {
+        let expectation = XCTestExpectation()
+        weak var weakConnection: RTMPConnection?
+        weak var weakStream: RTMPStream?
+
+        _ = {
+            let connection = RTMPConnection()
+            let stream = RTMPStream(connection: connection)
+            connection.connect("rtmp://localhost:1935/live")
+            stream.play("live")
+
+            DispatchQueue.main.async {
+                connection.close()
+                stream.close()
+                expectation.fulfill()
+            }
+
+            weakConnection = connection
+            weakStream = stream
+        }()
+
+        XCTWaiter().wait(for: [expectation], timeout: 1)
+        XCTAssertNil(weakConnection)
+        XCTAssertNil(weakStream)
+    }
+}


### PR DESCRIPTION
`RTMPStream` keeps waiting for the state change when the `readyState` is `.initialized`. It prevents  `RTMPStream` from closing the connection so it won't be deallocated after `close()` gets called.

This PR makes `RTMPStream` stop waiting for the state change when the stream is about to close so it can be deallocated.