### PR TITLE
fix layer (UIView.layer must be used from main thread only) used in custom lockQueue(com.haishinkit.HaishinKit.NetStream.lock)

### DIFF
--- a/Platforms/iOS/HKView.swift
+++ b/Platforms/iOS/HKView.swift
@@ -68,9 +68,11 @@ open class HKView: UIView {
         stream.mixer.session.commitConfiguration()
 
         stream.lockQueue.async {
-            stream.mixer.videoIO.drawable = self
-            self.currentStream = stream
-            stream.mixer.startRunning()
+            DispatchQueue.main.async {
+                stream.mixer.videoIO.drawable = self
+                self.currentStream = stream
+                stream.mixer.startRunning()
+            }
         }
     }
 }

--- a/Platforms/macOS/HKView.swift
+++ b/Platforms/macOS/HKView.swift
@@ -48,9 +48,11 @@ open class HKView: NSView {
             return
         }
         stream.lockQueue.async {
-            self.layer?.setValue(stream.mixer.session, forKey: "session")
-            stream.mixer.videoIO.drawable = self
-            stream.mixer.startRunning()
+            DispatchQueue.main.async {
+                self.layer?.setValue(stream.mixer.session, forKey: "session")
+                stream.mixer.videoIO.drawable = self
+                stream.mixer.startRunning()
+            }
         }
     }
 }


### PR DESCRIPTION
```
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIView layer]
PID: 11170, TID: 3730818, Thread name: (none), Queue name: com.haishinkit.HaishinKit.NetStream.lock, QoS: 0
Backtrace:
4   HaishinKit                          0x00000001012cb03c $s10HaishinKit6HKViewC5layerSo26AVCaptureVideoPreviewLayerCvg + 132
5   HaishinKit                          0x00000001012caf94 $s10HaishinKit6HKViewC5layerSo26AVCaptureVideoPreviewLayerCvgTo + 40
6   HaishinKit                          0x00000001012cb5c8 $s10HaishinKit6HKViewC11orientationSo25AVCaptureVideoOrientationVvW + 88
7   HaishinKit                          0x00000001012cba38 $s10HaishinKit6HKViewC11orientationSo25AVCaptureVideoOrientationVvs + 260
8   HaishinKit                          0x00000001012cd55c $s10HaishinKit6HKViewCAA17NetStreamDrawableA2aDP11orientationSo25AVCaptureVideoOrientationVvsTW + 36
9   HaishinKit                          0x00000001013ca44c $s10HaishinKit16VideoIOComponentC8drawableAA17NetStreamDrawable_pSgvW + 356
10  HaishinKit                          0x00000001013ca69c $s10HaishinKit16VideoIOComponentC8drawableAA17NetStreamDrawable_pSgvs + 368
11  HaishinKit                          0x00000001012cd374 $s10HaishinKit6HKViewC12attachStreamyyAA03NetE0CSgFyycfU_ + 380
12  HaishinKit                          0x000000010126ddbc $sIeg_IeyB_TR + 52
13  libdispatch.dylib                   0x0000000100e73260 _dispatch_call_block_and_release + 32
14  libdispatch.dylib                   0x0000000100e747e0 _dispatch_client_callout + 20
15  libdispatch.dylib                   0x0000000100e7ca84 _dispatch_lane_serial_drain + 716
16  libdispatch.dylib                   0x0000000100e7d78c _dispatch_lane_invoke + 412
17  libdispatch.dylib                   0x0000000100e874c4 _dispatch_workloop_worker_thread + 1172
18  libsystem_pthread.dylib             0x00000001aa72bab0 _pthread_wqthread + 308
19  libsystem_pthread.dylib             0x00000001aa731dc4 start_wqthread + 4
```

```
2019-04-17 17:49:49.283733+0800 [11170:3730818] [reports] Main Thread Checker: UI API called on a background thread: -[UIView layer]
PID: 11170, TID: 3730818, Thread name: (none), Queue name: com.haishinkit.HaishinKit.NetStream.lock, QoS: 0
Backtrace:
4   HaishinKit                          0x00000001012cb03c $s10HaishinKit6HKViewC5layerSo26AVCaptureVideoPreviewLayerCvg + 132
5   HaishinKit                          0x00000001012caf94 $s10HaishinKit6HKViewC5layerSo26AVCaptureVideoPreviewLayerCvgTo + 40
6   HaishinKit                          0x00000001012cb5c8 $s10HaishinKit6HKViewC11orientationSo25AVCaptureVideoOrientationVvW + 88
7   HaishinKit                          0x00000001012cba38 $s10HaishinKit6HKViewC11orientationSo25AVCaptureVideoOrientationVvs + 260
8   HaishinKit                          0x00000001012cd55c $s10HaishinKit6HKViewCAA17NetStreamDrawableA2aDP11orientationSo25AVCaptureVideoOrientationVvsTW + 36
9   HaishinKit                          0x00000001013ca44c $s10HaishinKit16VideoIOComponentC8drawableAA17NetStreamDrawable_pSgvW + 356
10  HaishinKit                          0x00000001013ca69c $s10HaishinKit16VideoIOComponentC8drawableAA17NetStreamDrawable_pSgvs + 368
11  HaishinKit                          0x00000001012cd374 $s10HaishinKit6HKViewC12attachStreamyyAA03NetE0CSgFyycfU_ + 380
12  HaishinKit                          0x000000010126ddbc $sIeg_IeyB_TR + 52
13  libdispatch.dylib                   0x0000000100e73260 _dispatch_call_block_and_release + 32
14  libdispatch.dylib                   0x0000000100e747e0 _dispatch_client_callout + 20
15  libdispatch.dylib                   0x0000000100e7ca84 _dispatch_lane_serial_drain + 716
16  libdispatch.dylib                   0x0000000100e7d78c _dispatch_lane_invoke + 412
17  libdispatch.dylib                   0x0000000100e874c4 _dispatch_workloop_worker_thread + 1172
18  libsystem_pthread.dylib             0x00000001aa72bab0 _pthread_wqthread + 308
19  libsystem_pthread.dylib             0x00000001aa731dc4 start_wqthread + 4
```