### PR TITLE
Fix: close before publish/connect to server, gonna crash

### DIFF
--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -461,7 +461,7 @@ open class RTMPStream: NetStream {
     }
 
     open func close() {
-        if readyState == .closed {
+        if readyState == .closed || readyState == .initialized {
             return
         }
         isBeingClosed = true


### PR DESCRIPTION
## just do
```swift
rtmpStream = RTMPStream(connection: rtmpConnection)
```

## then 
```swift
rtmpStream?.close()
```

## Crash

## Reason
`close` function check the `readyState` of Stream
```swift
if readyState == .closed {
    return
}
```
Should add one condition that is `.initialized`