### PR TITLE
Add did publish sufficient BW

### DIFF
--- a/Sources/RTMP/RTMPConnection.swift
+++ b/Sources/RTMP/RTMPConnection.swift
@@ -436,6 +436,10 @@ open class RTMPConnection: EventDispatcher {
                 for (_, stream) in streams {
                     stream.delegate?.didPublishInsufficientBW(stream, withConnection: self)
                 }
+            } else if count == 0 {
+                for (_, stream) in streams {
+                  stream.delegate?.didPublishSufficientBW(stream, withConnection: self)
+                }
             }
             previousQueueBytesOut.removeFirst()
         }

--- a/Sources/RTMP/RTMPStreamDelegate.swift
+++ b/Sources/RTMP/RTMPStreamDelegate.swift
@@ -1,4 +1,5 @@
 public protocol RTMPStreamDelegate: class {
     func didPublishInsufficientBW(_ stream: RTMPStream, withConnection: RTMPConnection)
+    func didPublishSufficientBW(_ stream: RTMPStream, withConnection: RTMPConnection)
     func clear()
 }


### PR DESCRIPTION
Busy working on a adaptive bitrates, `RTMPStreamDelegate` provides a way to lower the bitrate however I need a way to up the bitrate and I think this solution might work.

Usage:

```swift
let minBitrate: UInt32 = 300 * 1024
let maxBitrate: UInt32 = 2500 * 1024
let incrementBitrate: UInt32 = 512 * 1024

class MyRTMPStreamDelagate: RTMPStreamDelegate {
	@objc var onBWStatusChange: RCTDirectEventBlock?
	
	func didPublishInsufficientBW(_ stream: RTMPStream, withConnection: RTMPConnection) {
		guard var videoBitrate = stream.videoSettings["bitrate"] as? UInt32 else { return }
		print("didPublishInsufficientBW \(videoBitrate)")
		
		videoBitrate = UInt32(videoBitrate / 2)
		if videoBitrate < minBitrate {
			videoBitrate = minBitrate
		}
		stream.videoSettings["bitrate"] = videoBitrate
	}
	
	func didPublishSufficientBW(_ stream: RTMPStream, withConnection: RTMPConnection) {
		guard var videoBitrate = stream.videoSettings["bitrate"] as? UInt32 else { return }
		print("didPublishSufficientBW \(videoBitrate)")
		
		videoBitrate = videoBitrate + incrementBitrate
		if videoBitrate > maxBitrate {
			videoBitrate = maxBitrate
		}
		stream.videoSettings["bitrate"] = videoBitrate
	}
	
	func clear() {
	}
}
```