### PR TITLE
Feature/timeout reconnect

### DIFF
--- a/Examples/iOS/LiveViewController.swift
+++ b/Examples/iOS/LiveViewController.swift
@@ -130,11 +130,15 @@ final class LiveViewController: UIViewController {
             UIApplication.shared.isIdleTimerDisabled = false
             rtmpConnection.close()
             rtmpConnection.removeEventListener(Event.RTMP_STATUS, selector: #selector(rtmpStatusHandler), observer: self)
+            rtmpConnection.removeEventListener(Event.IO_ERROR, selector: #selector(rtmpErrorHandler), observer: self)
             publish.setTitle("●", for: [])
         } else {
             UIApplication.shared.isIdleTimerDisabled = true
             rtmpConnection.addEventListener(Event.RTMP_STATUS, selector: #selector(rtmpStatusHandler), observer: self)
-            rtmpConnection.connect(Preference.defaultInstance.uri!)
+            rtmpConnection.addEventListener(Event.IO_ERROR, selector: #selector(rtmpErrorHandler), observer: self)
+            /*rtmpConnection.connect(Preference.defaultInstance.uri!)*/
+            // FIXME: Remove
+            rtmpConnection.connect("rtmp://fake.tv")
             publish.setTitle("■", for: [])
         }
         publish.isSelected = !publish.isSelected
@@ -162,7 +166,17 @@ final class LiveViewController: UIViewController {
             break
         }
     }
-
+    
+    @objc
+    private func rtmpErrorHandler(_ notification: Notification) {
+        let e = Event.from(notification)
+        print("rtmpErrorHandler: \(e.description)")
+    
+        DispatchQueue.main.async {
+            self.rtmpConnection.connect(Preference.defaultInstance.uri!)
+        }
+    }
+    
     func tapScreen(_ gesture: UIGestureRecognizer) {
         if let gestureView = gesture.view, gesture.state == .ended {
             let touchPoint: CGPoint = gesture.location(in: gestureView)

--- a/Sources/RTMP/RTMPConnection.swift
+++ b/Sources/RTMP/RTMPConnection.swift
@@ -514,7 +514,11 @@ extension RTMPConnection: RTMPSocketDelegate {
         ), locked: nil)
         sequence += 1
     }
-
+    
+    func didReceiveTimeout() {
+        self.close(isDisconnected: true)
+    }
+    
     func listen(_ data: Data) {
         guard let chunk: RTMPChunk = currentChunk ?? RTMPChunk(data, size: socket.chunkSizeC) else {
             socket.inputBuffer.append(data)

--- a/Sources/RTMP/RTMPSocket.swift
+++ b/Sources/RTMP/RTMPSocket.swift
@@ -109,11 +109,6 @@ final class RTMPSocket: RTMPSocketCompatible {
 
     private init(_ socket: NetSocketCompatible) {
         self.socket = socket
-        self.socket.timeoutHandler = didTimeout
-        self.socket.inputHandler = didInputData
-        self.socket.didSetTotalBytesIn = didSetTotalBytesIn
-        self.socket.didSetTotalBytesOut = didSetTotalBytesOut
-        self.socket.didSetConnected = didSetConnected
     }
 
     func didSetTotalBytesIn(_ totalbytesIn: Int64) {
@@ -137,6 +132,12 @@ final class RTMPSocket: RTMPSocketCompatible {
     }
 
     func connect(withName: String, port: Int) {
+        socket.timeoutHandler = didTimeout
+        socket.inputHandler = didInputData
+        socket.didSetTotalBytesIn = didSetTotalBytesIn
+        socket.didSetTotalBytesOut = didSetTotalBytesOut
+        socket.didSetConnected = didSetConnected
+        
         socket.connect(withName: withName, port: port)
         handshake.clear()
         readyState = .uninitialized

--- a/Sources/RTMP/RTMPSocket.swift
+++ b/Sources/RTMP/RTMPSocket.swift
@@ -29,6 +29,7 @@ protocol RTMPSocketDelegate: IEventDispatcher {
     func listen(_ data: Data)
     func didSetReadyState(_ readyState: RTMPSocket.ReadyState)
     func didSetTotalBytesIn(_ totalBytesIn: Int64)
+    func didReceiveTimeout()
 }
 
 // MARK: -
@@ -201,7 +202,7 @@ final class RTMPSocket: RTMPSocketCompatible {
     }
 
     func didTimeout() {
-        deinitConnection(isDisconnected: false)
+        delegate?.didReceiveTimeout()
         delegate?.dispatch(Event.IO_ERROR, bubbles: false, data: nil)
         logger.warn("connection timedout")
     }


### PR DESCRIPTION
#### Description:

This WIP PR tries to solve the problem of connection after a timeout. 

#### Motivation:

Current behavior doesn't allow to connect the second time after initial connection timeout. Here is a sample scenario:
1. User tries to connect to RTMP server that doesn't exist "rtmp://fake.tv". That could happen if the user typed a wrong address.
2. `NetSocket` triggers `timeoutHandler` and `RTMPSocket.didTimeout` is executed. `didTimeout` calls `deinitConnection`. However, `NetSocket.runloop` isn't released, and `inputQueue` stays blocked by it. 
3. Any following call of `RTMPConnection.connect` won't trigger `NetSocket.initConnection` as `inputQueue` is blocked. 

#### Solution:
Instead of calling `deinitConnection`, `didTimeout` calls new delegate method `didReceiveTimeout`. It is implemented in `RTMPConnection` and calls `RTMPConnection.close()`. In this way, `socket.close()` is executed and `NetSocket.runloop` is released. 

#### Problem:
After calling `RTMPConnection.connect` again, `NetSocket` raises `EXC_BREAKPOINT` on `RTMPSocket:172` in `socket.inputBuffer.removeSubrange(0...RTMPHandshake.sigSize)` with following stack trace: 
<details>
  <summary>Click to expand</summary>

```
_dispatch_unfair_lock_wait 0x00000001bd93bd18
_dispatch_once_wait$VARIANT$mp 0x00000001bd93be8c
swift_getGenericMetadata 0x00000001ebc3758c
type metadata accessor for Swift.ClosedRange 0x00000001ebbc845c
type metadata accessor for Swift.ClosedRange<Swift.Int> 0x00000001023091f4
HaishinKit.RTMPSocket.didInputData() -> () RTMPSocket.swift:172
partial apply forwarder for HaishinKit.RTMPSocket.didInputData() -> () 0x00000001023d1c1c
HaishinKit.NetSocket.(doInput in _2F19F15DB5A1ACFB712D8A74CB6C271F)() -> () NetSocket.swift:193
HaishinKit.NetSocket.stream(_: __C.NSStream, handle: __C.NSStreamEvent) -> () NetSocket.swift:215
@objc HaishinKit.NetSocket.stream(_: __C.NSStream, handle: __C.NSStreamEvent) -> () 0x0000000102425e20
_signalEventSync 0x00000001bdeff2d8
_cfstream_solo_signalEventSync 0x00000001bdefc3dc
_CFStreamSignalEvent 0x00000001bdefc1bc
SocketStream::dispatchSignalFromSocketCallbackUnlocked(SocketStreamSignalHolder*) 0x00000001be5fcf50
SocketStream::socketCallback(__CFSocket*, unsigned long, __CFData const*, void const*) 0x00000001be60266c
SocketStream::_SocketCallBack_stream(__CFSocket*, unsigned long, __CFData const*, void const*, void*) 0x00000001be5fe528
__CFSocketPerformV0 0x00000001bdef39ac
__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ 0x00000001bdeec728
__CFRunLoopDoSource0 0x00000001bdeec6a8
__CFRunLoopDoSources0 0x00000001bdeebf90
__CFRunLoopRun 0x00000001bdee6ecc
CFRunLoopRunSpecific 0x00000001bdee67c0
-[NSRunLoop(NSRunLoop) runMode:beforeDate:] 0x00000001be8b4eac
-[NSRunLoop(NSRunLoop) run] 0x00000001be8f036c
HaishinKit.NetSocket.initConnection() -> () NetSocket.swift:163
closure #1 () -> () in HaishinKit.NetSocket.connect(withName: Swift.String, port: Swift.Int) -> () NetSocket.swift:55
reabstraction thunk helper from @escaping @callee_guaranteed () -> () to @escaping @callee_unowned @convention(block) () -> () 0x00000001022f7238
_dispatch_call_block_and_release 0x00000001bd998a38
_dispatch_client_callout 0x00000001bd9997d4
_dispatch_lane_serial_drain$VARIANT$mp 0x00000001bd942324
_dispatch_lane_invoke$VARIANT$mp 0x00000001bd942e40
_dispatch_workloop_worker_thread 0x00000001bd94b4ac
_pthread_wqthread 0x00000001bdb7a114
start_wqthread 0x00000001bdb7ccd4
```
</details>

It looks like something isn't fully deallocated inside of `NetSocket` when the host doesn't exist, and timeout is raised. The only temporary solution I've found yet is to recreate socket inside of `RTMPConnection` on each `connection`.

Everyone is more than welcome to help solve this issue. I've modified `LiveViewController` to easily reproduce it. Thank you in advance. 