### PR TITLE
TSWriter configurable segment duration and allow both mp4 and mov recordings from DefaultAVRecorderDelegate

### DIFF
--- a/Sources/ISO/TSWriter.swift
+++ b/Sources/ISO/TSWriter.swift
@@ -14,7 +14,7 @@ public class TSWriter: Running {
     public static let defaultVideoPID: UInt16 = 256
     public static let defaultAudioPID: UInt16 = 257
 
-    static let defaultSegmentDuration: Double = 2
+    public static let defaultSegmentDuration: Double = 2
 
     /// The delegate instance.
     public weak var delegate: TSWriterDelegate?
@@ -63,7 +63,8 @@ public class TSWriter: Running {
         return false
     }
 
-    public init() {
+    public init(segmentDuration: Double = TSWriter.defaultSegmentDuration) {
+        self.segmentDuration = segmentDuration
     }
 
     public func startRunning() {


### PR DESCRIPTION
### Pass tswriter segment duration to constructor
    
    Allow segment duration of a transport stream to be passed to the
    TSWriter constructor.
    
    Making the segment duration configurable allows for shorter data
    callback intervals which is useful for application which require lower
    latency between starting the stream and receiving first bytes (e.g.
    SRT).

### Allow mp4 or mov recordings from default recorder
    
    * Add DefaultAVRecorderDelegate.FileType enum with .mp4 and .mov cases
    * Add DefaultAVRecorderDelegate.fileType property
    * Default DefaultAVRecorderDelegate.fileType to .mp4
    * Initialize AVAssetWriter with proper AVFileType based on fileType
    * Take FileType in DefaultAVRecorderDelegate constructor