### PR TITLE
Fixed getting shared object with persistence

### DIFF
--- a/Sources/RTMP/RTMPMessage.swift
+++ b/Sources/RTMP/RTMPMessage.swift
@@ -516,7 +516,7 @@ final class RTMPSharedObjectMessage: RTMPMessage {
     }
 
     override func execute(_ connection: RTMPConnection, type: RTMPChunkType) {
-        let persistence: Bool = flags[0] == 0x01
+        let persistence: Bool = (flags[3] & 2) != 0
         RTMPSharedObject.getRemote(withName: sharedObjectName, remotePath: connection.uri!.absoluteWithoutQueryString, persistence: persistence).on(message: self)
     }
 }

--- a/Sources/RTMP/RTMPSharedObject.swift
+++ b/Sources/RTMP/RTMPSharedObject.swift
@@ -211,7 +211,7 @@ open class RTMPSharedObject: EventDispatcher {
                 objectEncoding: objectEncoding,
                 sharedObjectName: name,
                 currentVersion: succeeded ? 0 : currentVersion,
-                flags: Data([persistence ? 0x01 : 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+                flags: Data([0x00, 0x00, 0x00, persistence ? 0x02 : 0x00, 0x00, 0x00, 0x00, 0x00]),
                 events: events
             )
         )


### PR DESCRIPTION
When trying to connect to a shared object with persistence, I was receiving the following error from server:

`SharedObject.BadPersistence`

This PR fixes this issue.