### PR TITLE
Fix/rtmpdatamessage

### DIFF
--- a/Sources/RTMP/RTMPMessage.swift
+++ b/Sources/RTMP/RTMPMessage.swift
@@ -417,7 +417,7 @@ final class RTMPDataMessage: RTMPMessage {
         self.objectEncoding = objectEncoding
         self.handlerName = handlerName
         self.arguments = arguments
-        super.init(type: objectEncoding.commandType)
+        super.init(type: objectEncoding.dataType)
         self.streamId = streamId
     }
 

--- a/Sources/RTMP/RTMPMessage.swift
+++ b/Sources/RTMP/RTMPMessage.swift
@@ -410,7 +410,7 @@ final class RTMPDataMessage: RTMPMessage {
 
     init(objectEncoding: RTMPObjectEncoding) {
         self.objectEncoding = objectEncoding
-        super.init(type: objectEncoding.commandType)
+        super.init(type: objectEncoding.dataType)
     }
 
     init(streamId: UInt32, objectEncoding: RTMPObjectEncoding, handlerName: String, arguments: [Any?] = []) {


### PR DESCRIPTION
The RTMPDataMessage is being treated as a command by some RTMP servers, leading to errors such as:

`[ERROR] Unknown command { cmd: '@setDataFrame' }`