### PR TITLE
Xcode11のSwiftPMサポートに対応

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,21 +5,26 @@ import PackageDescription
 let package = Package(
     name: "HaishinKit",
     products: [
-        .library(name: "RTMP", targets: ["HTTP"]),
-        .library(name: "HTTP", targets: ["RTMP"])
+        .library(name: "HaishinKit", targets: ["HaishinKit"])
     ],
     dependencies: [
-        .Package(url: "https://github.com/shogo4405/Logboard.git", from: "2.1.2")
+        .package(url: "https://github.com/shogo4405/Logboard.git", from: "2.1.2")
     ],
     targets: [
-        .target(name: "Codec", dependencies: [])
-        .target(name: "Extension", dependencied: [])
-        .target(name: "HTTP", dependencies: [])
-        .target(name: "ISO", dependencies: [])
-        .target(name: "Media", dependencies: [])
-        .target(name: "Util", dependencies: [])
-        .target(name: "Net", dependencies: ["Codec", "Extension", "ISO", "Media", "Util"])
-        .target(name: "HTTP", dependencies: ["Net"])
-        .target(name: "RTMP", dependencies: ["Net", "FLV"])
+        .target(name: "SwiftPMSupport"),
+        .target(name: "HaishinKit", dependencies: ["Logboard", "SwiftPMSupport"],
+                path: "Sources",
+                sources: [
+                    "Codec",
+                    "Extension",
+                    "FLV",
+                    "ISO",
+                    "Media",
+                    "Net",
+                    "Util",
+                    "RTMP",
+                    "HTTP",
+                    "Platforms"
+                ])
     ]
 )

--- a/Platforms/iOS/DeviceUtil+Extenstion.swift
+++ b/Platforms/iOS/DeviceUtil+Extenstion.swift
@@ -1,4 +1,7 @@
+#if os(iOS)
+
 import AVFoundation
+import UIKit
 
 extension DeviceUtil {
     public static func videoOrientation(by notification: Notification) -> AVCaptureVideoOrientation? {
@@ -38,3 +41,5 @@ extension DeviceUtil {
         }
     }
 }
+
+#endif

--- a/Platforms/iOS/GLHKView.swift
+++ b/Platforms/iOS/GLHKView.swift
@@ -1,3 +1,5 @@
+#if os(iOS)
+
 import AVFoundation
 import GLKit
 
@@ -77,3 +79,5 @@ extension GLHKView: NetStreamDrawable {
         }
     }
 }
+
+#endif

--- a/Platforms/iOS/HKView.swift
+++ b/Platforms/iOS/HKView.swift
@@ -1,3 +1,5 @@
+#if os(iOS)
+
 import AVFoundation
 import UIKit
 
@@ -80,3 +82,5 @@ extension HKView: NetStreamDrawable {
     func draw(image: CIImage) {
     }
 }
+
+#endif

--- a/Platforms/iOS/MTHKView.swift
+++ b/Platforms/iOS/MTHKView.swift
@@ -1,3 +1,5 @@
+#if os(iOS)
+
 #if canImport(MetalKit)
 import AVFoundation
 import MetalKit
@@ -109,4 +111,6 @@ extension MTHKView: NetStreamDrawable {
         }
     }
 }
+#endif
+
 #endif

--- a/Platforms/iOS/NetStream+Extension.swift
+++ b/Platforms/iOS/NetStream+Extension.swift
@@ -1,3 +1,5 @@
+#if os(iOS)
+
 import AVFoundation
 import Foundation
 
@@ -25,3 +27,5 @@ extension NetStream {
         self.mixer.videoIO.setZoomFactor(zoomFactor, ramping: ramping, withRate: withRate)
     }
 }
+
+#endif

--- a/Platforms/iOS/ScreenCaptureSession.swift
+++ b/Platforms/iOS/ScreenCaptureSession.swift
@@ -1,6 +1,11 @@
+#if os(iOS)
+
 import AVFoundation
 import CoreImage
+
+#if os(iOS)
 import UIKit
+#endif
 
 public protocol ScreenCaptureOutputPixelBufferDelegate: class {
     func didSet(size: CGSize)
@@ -168,3 +173,5 @@ extension ScreenCaptureSession: Running {
         }
     }
 }
+
+#endif

--- a/Platforms/iOS/VideoIOComponent+Extension.swift
+++ b/Platforms/iOS/VideoIOComponent+Extension.swift
@@ -1,3 +1,5 @@
+#if os(iOS)
+
 import AVFoundation
 
 extension VideoIOComponent {
@@ -62,3 +64,5 @@ extension VideoIOComponent: ScreenCaptureOutputPixelBufferDelegate {
         mixer?.recorder.appendPixelBuffer(pixelBuffer, withPresentationTime: withPresentationTime)
     }
 }
+
+#endif

--- a/Platforms/macOS/DisplayLink-macOS.swift
+++ b/Platforms/macOS/DisplayLink-macOS.swift
@@ -1,3 +1,5 @@
+#if os(macOS)
+
 import CoreVideo
 import Foundation
 
@@ -41,3 +43,5 @@ final class DisplayLink: NSObject {
         status = CVDisplayLinkStop(displayLink)
     }
 }
+
+#endif

--- a/Platforms/macOS/GLHKView-macOS.swift
+++ b/Platforms/macOS/GLHKView-macOS.swift
@@ -1,3 +1,5 @@
+#if os(macOS)
+
 import AVFoundation
 import GLUT
 import OpenGL.GL3
@@ -111,3 +113,5 @@ extension GLHKView: NetStreamDrawable {
         }
     }
 }
+
+#endif

--- a/Platforms/macOS/HKView-macOS.swift
+++ b/Platforms/macOS/HKView-macOS.swift
@@ -1,3 +1,5 @@
+#if os(macOS)
+
 import AVFoundation
 
 open class HKView: NSView {
@@ -60,3 +62,5 @@ extension HKView: NetStreamDrawable {
     func draw(image: CIImage) {
     }
 }
+
+#endif

--- a/Platforms/macOS/NetStream+Extension-macOS.swift
+++ b/Platforms/macOS/NetStream+Extension-macOS.swift
@@ -1,3 +1,5 @@
+#if os(macOS)
+
 import AVFoundation
 import Foundation
 
@@ -8,3 +10,5 @@ extension NetStream {
         }
     }
 }
+
+#endif

--- a/Platforms/macOS/VideoIOComponent+Extension-macOS.swift
+++ b/Platforms/macOS/VideoIOComponent+Extension-macOS.swift
@@ -1,3 +1,5 @@
+#if os(macOS)
+
 import AVFoundation
 
 extension VideoIOComponent {
@@ -17,3 +19,5 @@ extension VideoIOComponent {
         }
     }
 }
+
+#endif

--- a/Platforms/tvOS/AVFoundation-tvOS.swift
+++ b/Platforms/tvOS/AVFoundation-tvOS.swift
@@ -1,3 +1,5 @@
+#if os(tvOS)
+
 import CoreMedia
 import Foundation
 
@@ -11,3 +13,5 @@ protocol AVCaptureVideoDataOutputSampleBufferDelegate: class {
 protocol AVCaptureAudioDataOutputSampleBufferDelegate: class {
     func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection)
 }
+
+#endif

--- a/Platforms/tvOS/GLHKView-tvOS.swift
+++ b/Platforms/tvOS/GLHKView-tvOS.swift
@@ -1,3 +1,5 @@
+#if os(tvOS)
+
 import AVFoundation
 import GLKit
 
@@ -65,3 +67,5 @@ extension GLHKView: NetStreamDrawable {
         }
     }
 }
+
+#endif

--- a/Platforms/tvOS/MTHKView-tvOS.swift
+++ b/Platforms/tvOS/MTHKView-tvOS.swift
@@ -1,11 +1,10 @@
+#if os(tvOS)
+
 import AVFoundation
 import MetalKit
 
 open class MTHKView: MTKView {
     public var videoGravity: AVLayerVideoGravity = .resizeAspect
-
-    var position: AVCaptureDevice.Position = .back
-    var orientation: AVCaptureVideoOrientation = .portrait
 
     var displayImage: CIImage?
     weak var currentStream: NetStream? {
@@ -27,8 +26,8 @@ open class MTHKView: MTKView {
 
     override open func awakeFromNib() {
         super.awakeFromNib()
-        delegate = self
         framebufferOnly = false
+        delegate = self
         enableSetNeedsDisplay = true
     }
 
@@ -36,7 +35,6 @@ open class MTHKView: MTKView {
         if let stream: NetStream = stream {
             stream.mixer.videoIO.context = CIContext(mtlDevice: device!)
             stream.lockQueue.async {
-                self.position = stream.mixer.videoIO.position
                 stream.mixer.videoIO.drawable = self
                 stream.mixer.startRunning()
             }
@@ -50,13 +48,18 @@ extension MTHKView: MTKViewDelegate {
     public func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
     }
 
+#if arch(i386) || arch(x86_64)
+    public func draw(in view: MTKView) {
+        // tvOS Simulator doesn't support currentDrawable as CAMetalDrawable.
+    }
+#else
     public func draw(in view: MTKView) {
         guard
             let drawable: CAMetalDrawable = currentDrawable,
             let image: CIImage = displayImage,
             let commandBuffer: MTLCommandBuffer = device?.makeCommandQueue()?.makeCommandBuffer(),
             let context: CIContext = currentStream?.mixer.videoIO.context else {
-            return
+                return
         }
         var scaleX: CGFloat = 0
         var scaleY: CGFloat = 0
@@ -89,6 +92,7 @@ extension MTHKView: MTKViewDelegate {
         commandBuffer.present(drawable)
         commandBuffer.commit()
     }
+#endif
 }
 
 extension MTHKView: NetStreamDrawable {
@@ -96,7 +100,9 @@ extension MTHKView: NetStreamDrawable {
     func draw(image: CIImage) {
         DispatchQueue.main.async {
             self.displayImage = image
-            self.needsDisplay = true
+            self.setNeedsDisplay()
         }
     }
 }
+
+#endif

--- a/Sources/Codec/H264Decoder.swift
+++ b/Sources/Codec/H264Decoder.swift
@@ -3,6 +3,10 @@ import CoreFoundation
 import CoreVideo
 import VideoToolbox
 
+#if os(iOS)
+import UIKit
+#endif
+
 protocol VideoDecoderDelegate: class {
     func sampleOutput(video sampleBuffer: CMSampleBuffer)
 }

--- a/Sources/Codec/H264Encoder.swift
+++ b/Sources/Codec/H264Encoder.swift
@@ -2,6 +2,10 @@ import AVFoundation
 import CoreFoundation
 import VideoToolbox
 
+#if os(iOS)
+import UIKit
+#endif
+
 protocol VideoEncoderDelegate: class {
     func didSetFormatDescription(video formatDescription: CMFormatDescription?)
     func sampleOutput(video sampleBuffer: CMSampleBuffer)

--- a/Sources/Extension/CVPixelBuffer+Extension.swift
+++ b/Sources/Extension/CVPixelBuffer+Extension.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreVideo
 
 extension CVPixelBuffer {
     var width: Int {

--- a/Sources/FLV/FLVTagType.swift
+++ b/Sources/FLV/FLVTagType.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public enum FLVTagType: UInt8 {
     case audio = 8
     case video = 9

--- a/Sources/HTTP/M3U.swift
+++ b/Sources/HTTP/M3U.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /**
  - seealso: https://tools.ietf.org/html/draft-pantos-http-live-streaming-19
  */

--- a/Sources/ISO/TSWriter.swift
+++ b/Sources/ISO/TSWriter.swift
@@ -2,6 +2,10 @@ import AVFoundation
 import CoreMedia
 import Foundation
 
+#if canImport(SwiftPMSupport)
+import SwiftPMSupport
+#endif
+
 /// MPEG-2 TS (Transport Stream) Writer delegate
 public protocol TSWriterDelegate: class {
     func didOutput(_ data: Data)

--- a/Sources/Media/AudioIOComponent.swift
+++ b/Sources/Media/AudioIOComponent.swift
@@ -1,5 +1,9 @@
 import AVFoundation
 
+#if canImport(SwiftPMSupport)
+import SwiftPMSupport
+#endif
+
 final class AudioIOComponent: IOComponent {
     lazy var encoder = AudioConverter()
     let lockQueue = DispatchQueue(label: "com.haishinkit.HaishinKit.AudioIOComponent.lock")

--- a/Sources/Media/VideoIOComponent.swift
+++ b/Sources/Media/VideoIOComponent.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreImage
 
 final class VideoIOComponent: IOComponent {
     #if os(macOS)

--- a/Sources/Net/NetStream.swift
+++ b/Sources/Net/NetStream.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreImage
 
 protocol NetStreamDrawable: class {
 #if os(iOS) || os(macOS)

--- a/Sources/Platforms
+++ b/Sources/Platforms
@@ -1,0 +1,1 @@
+../Platforms

--- a/Sources/SwiftPMSupport/dummy.m
+++ b/Sources/SwiftPMSupport/dummy.m
@@ -1,0 +1,3 @@
+#import "HaishinKit.h"
+
+void HaishinKit_SwiftPMSupport_dummy_symbol() {}

--- a/Sources/SwiftPMSupport/include/HaishinKit.h
+++ b/Sources/SwiftPMSupport/include/HaishinKit.h
@@ -1,0 +1,21 @@
+#import <UIKit/UIKit.h>
+
+static NSString *const __nonnull HaishinKitIdentifier = @"com.haishinkit.HaishinKit";
+FOUNDATION_EXPORT double HaishinKitVersionNumber;
+FOUNDATION_EXPORT const unsigned char HaishinKitVersionString[];
+
+// @see http://stackoverflow.com/questions/35119531/catch-objective-c-exception-in-swift
+NS_INLINE void nstry(void(^_Nonnull lambda)(void), void(^_Nullable error)(NSException *_Nonnull exception)) {
+    @try {
+        lambda();
+    }
+    @catch (NSException *exception) {
+        if (error != NULL) {
+            @try {
+                error(exception);
+            }@catch(NSException *exception) {
+
+            }
+        }
+    }
+}

--- a/Sources/Util/Constants.swift
+++ b/Sources/Util/Constants.swift
@@ -1,3 +1,7 @@
 import Logboard
 
+#if canImport(SwiftPMSupport)
+import SwiftPMSupport
+#endif
+
 let logger = Logboard.with(HaishinKitIdentifier)

--- a/Sources/Util/DataConvertible.swift
+++ b/Sources/Util/DataConvertible.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 protocol DataConvertible {
     var data: Data { get set }
 }


### PR DESCRIPTION
Xcode11のSwiftPMサポートに対応しました。
HaishinKitをアプリの依存ライブラリとしてXcode上からSwiftPMパッケージとして追加できるようになります。

変更として微妙な部分もあると思っており、
特にマージしてほしいと強く思ってはいません。
それでも、shogo4405さんや他のユーザに対する知見の共有のメリットが有ると思うので、
GitHub上のPRエントリを出させていただきます。

### ターゲット構成

2つのターゲットでビルドしています。
HaishinKit.hを利用するためにObjective-Cターゲットが必要で、
Swiftターゲットとは統合できないため、2つになっています。

元々Package.swiftにディレクトリ別のパッケージ構成が書かれていたため、
それを踏襲しようと試みましたが、

visibilityがinternalになっている部分や、
パッケージ間の循環依存関係が生じる部分があって、できませんでした。

### ソース修正

CoreVideoやUIKitなど、システムライブラリのimport文が足りない部分があったので、追記しています。
Xcodeではimport文が無くても大丈夫だが、SwiftPMでは駄目な事があります。

### Platforms関係

PlatformsディレクトリをSources配下に置く必要があるのでシンボリックリンクを作りました。

本当はターゲットプラットフォームごとにビルドするソースコードを変化させたかったのですが、
Package.swift側でその切り替えを指定する方法がわからなかったので、
全てのソースを必ずビルドするようにしました。

ただ、ターゲットプラットフォームと異なるソースはコンパイルできないので、
それらのソースは`#if os(...)`による全体のガードを追加しました。

また、同名のファイル名が複数あるとビルドできないので、
`-macOS`と`-tvOS`のsuffixを追加するファイル名変更をしました。

### リポジトリ名について

XcodeのSwiftPMサポートのバグで、
リポジトリの名前が`HaishinKit.swift`だと、
override editができませんでした。
そこで僕のフォークでは`HaishinKit-swift`にリネームしました。
override editを使うときにはXcodeの左ペインにディレクトリをドロップするGUI操作を行うのですが、
おそらくここで`.swift`というディレクトリ名のsuffixがソースコードとして判定される事に起因しています。
依存先として使う限りには問題はないですが、
実践的にはoverride editができないのは不便なので、
リネームを検討したほうが良いかもしれません。