### PR TITLE
videoSettingsの.mutedを指定していても映像の送信が継続してしまう問題の修正

### DIFF
--- a/Sources/Codec/H264Encoder.swift
+++ b/Sources/Codec/H264Encoder.swift
@@ -253,6 +253,18 @@ public final class H264Encoder {
         guard let session: VTCompressionSession = session else {
             return
         }
+        if lastImageBuffer == nil {
+            var pixelBuffer: CVPixelBuffer?
+            CVPixelBufferCreate(
+                kCFAllocatorDefault,
+                imageBuffer.width,
+                imageBuffer.height,
+                kCVPixelFormatType_32BGRA,
+                nil,
+                &pixelBuffer
+            )
+            lastImageBuffer = pixelBuffer
+        }
         var flags: VTEncodeInfoFlags = []
         VTCompressionSessionEncodeFrame(
             session,


### PR DESCRIPTION
**概要**

`RTMPStream.videoSettings` の `.muted` に `true` を指定していても、映像の送信が継続してしまう問題の修正です。
`RTMPStream.videoSettings` の `.muted` が `true` 場合、最後の映像バッファがエンコードされるべきですが、最後の映像バッファがまだ設定されていなかった場合に現在の映像バッファがエンコードされ送信されてしまっています。

**修正内容**

H264Encoderにおいて、最後の映像バッファを初期化するように修正しました。
初期化の際の映像は黒・サイズは元の映像サイズとなります。