### PR TITLE
maxKeyFrameIntervalDurationがIntだと設定されない

### DIFF
--- a/Sources/Util/Setting.swift
+++ b/Sources/Util/Setting.swift
@@ -78,6 +78,8 @@ public class Setting<T: AnyObject, Key: KeyPathRepresentable>: ExpressibleByDict
             return Double(value)
         case let value as Double:
             return value
+        case let value as Int:
+            return Double(value)
         default:
             return nil
         }


### PR DESCRIPTION
READMEではmaxKeyFrameIntervalDurationをIntで設定していますが、Doubleに変換するところで捨てられて設定されていませんでした。