### PR TITLE
[Carthage Support] Turn on 'Enable Testability' for release scheme

### DIFF
--- a/HaishinKit.xcodeproj/project.pbxproj
+++ b/HaishinKit.xcodeproj/project.pbxproj
@@ -2261,6 +2261,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",


### PR DESCRIPTION
## Context

Hi, our company uses `HaishinKit` via Cocoapod and now try to migrate Carthage.

We made some test stub like below, and need to import `HaishinKit` with `@testable` to access internal properties.

With Carthage an issue occurs when we try to build for testing.

`Module 'HaishinKit' was not compiled for testing`

<img width="795" alt="Screen Shot 2020-03-12 at 6 25 50 PM" src="https://user-images.githubusercontent.com/2222333/76506790-142fcf80-648f-11ea-89e4-7145c5890202.png">


## Suggestion

I suggest turning on `ENABLE_TESTABILITY` to `YES` also for the release scheme. 
(Like the screenshot below)
After that, HaishinKit framework which is prebuilt by Carthage (made with Release Scheme) can be used for testing.
I tested it compiled successfully with my forked repo. Also all tests we wrote are passed too.

<img width="663" alt="Screen Shot 2020-03-12 at 6 15 39 PM" src="https://user-images.githubusercontent.com/2222333/76505853-80a9cf00-648d-11ea-989c-d9df48363dcd.png">
 

```swift
@testable import HaishinKit
import SOMETHING

final class RTMPSocketStub: RTMPSocketCompatible {
  ...
  var delegate: RTMPSocketDelegate?
  ...
  var readyState: RTMPSocketReadyState = .uninitialized
  var chunkSizeC: Int = RTMPChunk.defaultSize
  var chunkSizeS: Int = RTMPChunk.defaultSize
  ...
  var securityLevel: StreamSocketSecurityLevel = .none
  var qualityOfService: DispatchQoS = .default

  @discardableResult
  func doOutput(chunk: RTMPChunk, locked: UnsafeMutablePointer<UInt32>?) -> Int {
    Stubber.invoke(doOutput, args: (chunk, locked), default: 0)
  }

  ...
  func connect(withName: String, port: Int) {
    Stubber.invoke(connect, args: (withName, port), default: Void())
  }

  func deinitConnection(isDisconnected: Bool) {
    Stubber.invoke(deinitConnection, args: isDisconnected, default: Void())
  }

  ...
}
```