### PR TITLE
Fix SPM support

### DIFF
--- a/Platforms/iOS/VideoIOComponent+Extension.swift
+++ b/Platforms/iOS/VideoIOComponent+Extension.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 
 import AVFoundation
+import CoreImage
 
 extension VideoIOComponent {
     var zoomFactor: CGFloat {

--- a/Sources/Net/NetStreamRenderer.swift
+++ b/Sources/Net/NetStreamRenderer.swift
@@ -4,6 +4,7 @@ import Foundation
 #if os(macOS)
 typealias NetStreamRendererView = NSView
 #else
+import UIKit
 typealias NetStreamRendererView = UIView
 #endif
 

--- a/Sources/RTMP/RTMPStreamInfo.swift
+++ b/Sources/RTMP/RTMPStreamInfo.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /**
  flash.net.NetStreamInfo for Swift
  */


### PR DESCRIPTION
Swift Package Manager in Xcode 11 will fail because some import statements are missing. This PR fixes that.