### PR TITLE
Fix main thread access in HKView

### DIFF
--- a/Platforms/iOS/HKView.swift
+++ b/Platforms/iOS/HKView.swift
@@ -26,9 +26,20 @@ open class HKView: UIView {
 
     var orientation: AVCaptureVideoOrientation = .portrait {
         didSet {
-            layer.connection.map {
-                if $0.isVideoOrientationSupported {
-                    $0.videoOrientation = orientation
+            let orientationChange = { [weak self] in
+                guard let strongSelf = self else { return }
+                strongSelf.layer.connection.map {
+                    if $0.isVideoOrientationSupported {
+                        $0.videoOrientation = strongSelf.orientation
+                    }
+                }
+            }
+            
+            if Thread.isMainThread {
+                orientationChange()
+            } else {
+                DispatchQueue.main.sync {
+                    orientationChange()
                 }
             }
         }


### PR DESCRIPTION
When HKView's `attachStream` is called, it uses the `lockQueue` to set the `stream.mixer.videoIO.renderer`, but this results in the didSet of that property trying to set HKView's `orientation` property, which accesses the CALayer `layer` property while on `lockQueue`.

This PR ensures that the `layer` property is accessed synchronously on the main queue. Camera output appears much faster on view load, Xcode's Main Thread Checker no longer complains.