### PR TITLE
Add mirrored orientation adjustment for front facing camera when using MTHKView.

### DIFF
--- a/Platforms/iOS/MTHKView.swift
+++ b/Platforms/iOS/MTHKView.swift
@@ -103,7 +103,8 @@ extension MTHKView: MTKViewDelegate {
             break
         }
         let bounds = CGRect(origin: .zero, size: drawableSize)
-        let scaledImage: CIImage = displayImage
+        let adjustedImage = position == .front ? image.oriented(forExifOrientation: 2) : image
+        let scaledImage: CIImage = adjustedImage
             .transformed(by: CGAffineTransform(translationX: translationX, y: translationY))
             .transformed(by: CGAffineTransform(scaleX: scaleX, y: scaleY))
         context.render(scaledImage, to: currentDrawable.texture, commandBuffer: commandBuffer, bounds: bounds, colorSpace: colorSpace)


### PR DESCRIPTION
This addresses https://github.com/shogo4405/HaishinKit.swift/issues/674

This PR matches the functionality in GLHKView. When rendering the video preview, check if the front facing camera is being used, and if so, apply the "up mirrored" orientation.

From GLHKView:
```
if position == .front {
  currentStream?.mixer.videoIO.context?.draw(displayImage.oriented(forExifOrientation: 2), in: inRect, from: fromRect)
} else {
  currentStream?.mixer.videoIO.context?.draw(displayImage, in: inRect, from: fromRect)
}
```

Suggested change for consistency in MTHKView:
```
let adjustedImage = position == .front ? image.oriented(forExifOrientation: 2) : image
let scaledImage: CIImage = adjustedImage
  .transformed(by: CGAffineTransform(translationX: translationX, y: translationY))
  .transformed(by: CGAffineTransform(scaleX: scaleX, y: scaleY))
```
