### PR TITLE
Fix renderer life cycle issue

### DIFF
--- a/Sources/Media/VideoIOComponent.swift
+++ b/Sources/Media/VideoIOComponent.swift
@@ -27,13 +27,13 @@ final class VideoIOComponent: IOComponent {
     }
 
     #if os(iOS) || os(macOS)
-    var renderer: NetStreamRenderer? = nil {
+    weak var renderer: NetStreamRenderer? = nil {
         didSet {
             renderer?.orientation = orientation
         }
     }
     #else
-    var renderer: NetStreamRenderer?
+    weak var renderer: NetStreamRenderer?
     #endif
 
     var formatDescription: CMVideoFormatDescription? {


### PR DESCRIPTION
This PR fixes an issue where `VideoIOComponent` may cause the renderer's life cycle management to get messed up.

## Steps to reproduce

- Push a new view controller that contains a `HKView` (or any other renderer, so a streaming view controller) onto the navigation stack
- Pop the view controller from the navigation stack
- Check life cycle on `deinit`, the view controller is destroyed as expected, but it takes quite a long time for the `HKView` to get destroyed
- If you try to push another streaming view controller onto the navigation stack before the earlier one's `HKView` is destroyed, then the new one gets stuck 

I tested this from the branch by rapidly pushing a view controller that contains a `HKView` onto the navigation stack from a list item and popping it instantly and pushing a new one and it seems to work fine now.