### PR TITLE
feat: add isMirrored property for GLHKView and MTHKView

### DIFF
--- a/Platforms/iOS/GLHKView.swift
+++ b/Platforms/iOS/GLHKView.swift
@@ -15,6 +15,7 @@ open class GLHKView: GLKView, NetStreamRenderer {
     }
     var position: AVCaptureDevice.Position = .back
     var orientation: AVCaptureVideoOrientation = .portrait
+    var isMirrored: Bool = false
     var displayImage: CIImage?
     private weak var currentStream: NetStream? {
         didSet {
@@ -57,11 +58,20 @@ extension GLHKView: GLKViewDelegate {
     // MARK: GLKViewDelegate
     public func glkView(_ view: GLKView, drawIn rect: CGRect) {
         glClear(GLbitfield(GL_COLOR_BUFFER_BIT))
-        guard let displayImage: CIImage = displayImage else {
+        guard var displayImage: CIImage = displayImage else {
             return
         }
         var inRect = CGRect(x: 0, y: 0, width: CGFloat(drawableWidth), height: CGFloat(drawableHeight))
         var fromRect: CGRect = displayImage.extent
+
+        if isMirrored {
+            if #available(iOS 11.0, *) {
+                displayImage = displayImage.oriented(.upMirrored)
+            } else {
+                displayImage = displayImage.oriented(forExifOrientation: 2)
+            }
+        }
+
         VideoGravityUtil.calculate(videoGravity, inRect: &inRect, fromRect: &fromRect)
         currentStream?.mixer.videoIO.context?.draw(displayImage, in: inRect, from: fromRect)
     }

--- a/Platforms/iOS/MTHKView.swift
+++ b/Platforms/iOS/MTHKView.swift
@@ -13,6 +13,7 @@ open class MTHKView: MTKView, NetStreamRenderer {
 
     var position: AVCaptureDevice.Position = .back
     var orientation: AVCaptureVideoOrientation = .portrait
+    var isMirrored: Bool = false
 
     var displayImage: CIImage?
     weak var currentStream: NetStream? {
@@ -103,9 +104,18 @@ extension MTHKView: MTKViewDelegate {
             break
         }
         let bounds = CGRect(origin: .zero, size: drawableSize)
-        let scaledImage: CIImage = displayImage
+        var scaledImage: CIImage = displayImage
             .transformed(by: CGAffineTransform(translationX: translationX, y: translationY))
             .transformed(by: CGAffineTransform(scaleX: scaleX, y: scaleY))
+
+        if isMirrored {
+            if #available(iOS 11.0, *) {
+                scaledImage = scaledImage.oriented(.upMirrored)
+            } else {
+                scaledImage = scaledImage.oriented(forExifOrientation: 2)
+            }
+        }
+
         context.render(scaledImage, to: currentDrawable.texture, commandBuffer: commandBuffer, bounds: bounds, colorSpace: colorSpace)
         commandBuffer.present(currentDrawable)
         commandBuffer.commit()


### PR DESCRIPTION
# Description
I add `isMirrored` property for GLHKView and MTHKView, so the view can be mirrored when `rtmpStream.captureSettings[.isVideoMirrored]` is set true.

I did not add a mirror button on the UI, because there's no button for setting `rtmpStream.captureSettings[.isVideoMirrored]` to true yet. We may need manual testing for this part, or I can add the UI later if needed.

I hope this new property is clear and useful enough.