### PR TITLE
H.264にエンコードされた後のCMSampleBufferを参照可能にする

### DIFF
--- a/Sources/Codec/H264Encoder.swift
+++ b/Sources/Codec/H264Encoder.swift
@@ -6,7 +6,7 @@ import VideoToolbox
 import UIKit
 #endif
 
-protocol VideoEncoderDelegate: class {
+public protocol VideoEncoderDelegate: class {
     func didSetFormatDescription(video formatDescription: CMFormatDescription?)
     func sampleOutput(video sampleBuffer: CMSampleBuffer)
 }

--- a/Sources/ISO/TSWriter.swift
+++ b/Sources/ISO/TSWriter.swift
@@ -230,7 +230,7 @@ extension TSWriter: AudioConverterDelegate {
 
 extension TSWriter: VideoEncoderDelegate {
     // MARK: VideoEncoderDelegate
-    func didSetFormatDescription(video formatDescription: CMFormatDescription?) {
+    public func didSetFormatDescription(video formatDescription: CMFormatDescription?) {
         guard
             let formatDescription: CMFormatDescription = formatDescription,
             let avcC: Data = AVCConfigurationRecord.getData(formatDescription) else {
@@ -244,7 +244,7 @@ extension TSWriter: VideoEncoderDelegate {
         videoConfig = AVCConfigurationRecord(data: avcC)
     }
 
-    func sampleOutput(video sampleBuffer: CMSampleBuffer) {
+    public func sampleOutput(video sampleBuffer: CMSampleBuffer) {
         guard let dataBuffer = sampleBuffer.dataBuffer else {
             return
         }


### PR DESCRIPTION
**背景**

HTTPStreamのTSWriterで行っているように、以下のような独自のNetStreamを定義し、H.264にエンコードされた後のCMSampleBufferを参照したいが、VideoEncoderDelegateがpublicではないため利用できない。

```swift
open class FooStream: NetStream {
    private let fooPacketizer: FooBacketizer

    ...

    open func publish(_ name: String?) {
        self.mixer.startEncoding(delegate: fooPacketizer)
        self.mixer.startRunning()
    }
}

class FooPacketizer {
}

extension FooPacketizer: VideoEncoderDelegate {
    public func didSetFormatDescription(video formatDescription: CMFormatDescription?) {
        ...
    }
    public func sampleOutput(video sampleBuffer: CMSampleBuffer) {
        ...
    }
}

extension FooPacketizer: AudioConverterDelegate {
    public func didSetFormatDescription(audio formatDescription: CMFormatDescription?) {
        ...
    }
    public func sampleOutput(audio data: UnsafeMutableAudioBufferListPointer, presentationTimeStamp: CMTime) {
        ...
    }
}
```

**変更内容**

- VideoEncoderDelegateをpublicにする（AudioConverterDelegateはすでにpublic）
