### PR TITLE
fix: Sometimes the streaming can't start

### DIFF
--- a/Sources/Net/NetSocket.swift
+++ b/Sources/Net/NetSocket.swift
@@ -157,14 +157,16 @@ open class NetSocket: NSObject {
         inputStream?.close()
         inputStream?.remove(from: runloop, forMode: .default)
         inputStream?.delegate = nil
-        inputStream = nil
         outputStream?.close()
         outputStream?.remove(from: runloop, forMode: .default)
         outputStream?.delegate = nil
-        outputStream = nil
         self.runloop = nil
         CFRunLoopStop(runloop.getCFRunLoop())
         logger.trace("isDisconnected: \(isDisconnected)")
+        inputQueue.async {
+            self.inputStream = nil
+            self.outputStream = nil
+        }
     }
 
     func didTimeout() {


### PR DESCRIPTION
Sometimes the streaming can't start, and the [initialization](https://github.com/shogo4405/HaishinKit.swift/blob/91cfb2c8d6f21a7f8753d43546691a6ae012788b/Sources/Net/NetSocket.swift#L120) is no longer executed after reproducing this issue.

There was a race condition in the thread at the following locations.
https://github.com/shogo4405/HaishinKit.swift/blob/91cfb2c8d6f21a7f8753d43546691a6ae012788b/Sources/Net/NetSocket.swift#L38
https://github.com/shogo4405/HaishinKit.swift/blob/91cfb2c8d6f21a7f8753d43546691a6ae012788b/Sources/Net/NetSocket.swift#L164

version: 1.0.9

----

This issue may be closed: https://github.com/shogo4405/HaishinKit.swift/issues/724