### PR TITLE
Allow Coding Guidelines for Cocoa Delegate method section

### DIFF
--- a/Sources/RTMP/RTMPConnection.swift
+++ b/Sources/RTMP/RTMPConnection.swift
@@ -441,17 +441,17 @@ open class RTMPConnection: EventDispatcher {
             }
             if total == measureInterval - 1 {
                 for (_, stream) in streams {
-                    stream.delegate?.didPublishInsufficientBW(stream, withConnection: self)
+                    stream.delegate?.rtmpStream(stream, didPublishInsufficientBW: self)
                 }
             } else if total == 0 {
                 for (_, stream) in streams {
-                    stream.delegate?.didPublishSufficientBW(stream, withConnection: self)
+                    stream.delegate?.rtmpStream(stream, didPublishSufficientBW: self)
                 }
             }
             previousQueueBytesOut.removeFirst()
         }
         for (_, stream) in streams {
-            stream.delegate?.didStatics(stream, withConneciton: self)
+            stream.delegate?.rtmpStream(stream, didStatics: self)
         }
     }
 }

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -277,7 +277,7 @@ open class RTMPStream: NetStream {
                 currentFPS = 0
                 frameCount = 0
                 info.clear()
-                delegate?.clear()
+                delegate?.rtmpStreamDidClear(self)
             case .playing:
                 mixer.delegate = self
                 mixer.startDecoding(rtmpConnection.audioEngine)
@@ -631,10 +631,10 @@ extension RTMPStream: AVMixerDelegate {
     // MARK: AVMixerDelegate
     func didOutputVideo(_ buffer: CMSampleBuffer) {
         frameCount += 1
-        delegate?.didOutputVideo(buffer)
+        delegate?.rtmpStream(self, didOutput: buffer)
     }
 
     func didOutputAudio(_ buffer: AVAudioPCMBuffer, presentationTimeStamp: CMTime) {
-        delegate?.didOutputAudio(buffer, presentationTimeStamp: presentationTimeStamp)
+        delegate?.rtmpStream(self, didOutput: buffer, presentationTimeStamp: presentationTimeStamp)
     }
 }

--- a/Sources/RTMP/RTMPStreamDelegate.swift
+++ b/Sources/RTMP/RTMPStreamDelegate.swift
@@ -2,19 +2,21 @@ import AVFoundation
 import CoreMedia
 
 public protocol RTMPStreamDelegate: class {
-    func didPublishInsufficientBW(_ stream: RTMPStream, withConnection: RTMPConnection)
-    func didPublishSufficientBW(_ stream: RTMPStream, withConnection: RTMPConnection)
-    func didOutputAudio(_ buffer: AVAudioPCMBuffer, presentationTimeStamp: CMTime)
-    func didOutputVideo(_ buffer: CMSampleBuffer)
-    func didStatics(_ stream: RTMPStream, withConneciton: RTMPConnection)
-    func clear()
+    func rtmpStream(_ stream: RTMPStream, didPublishInsufficientBW connection: RTMPConnection)
+    func rtmpStream(_ stream: RTMPStream, didPublishSufficientBW connection: RTMPConnection)
+    func rtmpStream(_ stream: RTMPStream, didOutput audio: AVAudioBuffer, presentationTimeStamp: CMTime)
+    func rtmpStream(_ stream: RTMPStream, didOutput video: CMSampleBuffer)
+    func rtmpStream(_ stream: RTMPStream, didStatics connection: RTMPConnection)
+    func rtmpStreamDidClear(_ stream: RTMPStream)
 }
 
 public extension RTMPStreamDelegate {
-    func didStatics(_ stream: RTMPStream, withConneciton: RTMPConnection) {
+    func rtmpStream(_ stream: RTMPStream, didStatics connection: RTMPConnection) {
     }
-    func didOutputAudio(_ buffer: AVAudioPCMBuffer, presentationTimeStamp: CMTime) {
+
+    func rtmpStream(_ stream: RTMPStream, didOutput audio: AVAudioBuffer, presentationTimeStamp: CMTime) {
     }
-    func didOutputVideo(_ buffer: CMSampleBuffer) {
+
+    func rtmpStream(_ stream: RTMPStream, didOutput video: CMSampleBuffer) {
     }
 }


### PR DESCRIPTION
https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingMethods.html