### PR TITLE
Use DisplayLink timestamp instead of clockReference

### DIFF
--- a/Sources/Util/DisplayLinkedQueue.swift
+++ b/Sources/Util/DisplayLinkedQueue.swift
@@ -69,7 +69,7 @@ final class DisplayLinkedQueue: NSObject {
                 delegate?.empty()
             }
         }
-        let current = clockReference?.duration ?? duration
+        let current = duration
         let targetTimestamp = first.presentationTimeStamp.seconds + first.duration.seconds
         if targetTimestamp < current {
             buffer.removeFirst()


### PR DESCRIPTION
Using clockReference duration may break time logic and audio video sync if video was freezed on streamer side