### PR TITLE
Keep focus and exposure modes when using pointOfInterest

### DIFF
--- a/Sources/Media/VideoIOComponent.swift
+++ b/Sources/Media/VideoIOComponent.swift
@@ -184,7 +184,7 @@ final class VideoIOComponent: IOComponent {
             do {
                 try device.lockForConfiguration()
                 device.focusPointOfInterest = point
-                device.focusMode = .continuousAutoFocus
+                device.focusMode = continuousAutofocus ? .continuousAutoFocus : .autoFocus
                 device.unlockForConfiguration()
             } catch let error as NSError {
                 logger.error("while locking device for focusPointOfInterest: \(error)")
@@ -203,7 +203,7 @@ final class VideoIOComponent: IOComponent {
             do {
                 try device.lockForConfiguration()
                 device.exposurePointOfInterest = point
-                device.exposureMode = .continuousAutoExposure
+                device.exposureMode = continuousExposure ? .continuousAutoExposure : .autoExpose
                 device.unlockForConfiguration()
             } catch let error as NSError {
                 logger.error("while locking device for exposurePointOfInterest: \(error)")


### PR DESCRIPTION
Change to keep device settings for focusMode and exposureMode when using PointOfInterest.

Currently using PointOfInterest for focus and exposure always overrides with the continuous modes.
It should be possible to use pointOfInterest with both continues and auto modes.