### PR TITLE
fixed #793, looks like the M1 needs metal compat specified in default…

### DIFF
--- a/Examples/macOS/MainViewController.swift
+++ b/Examples/macOS/MainViewController.swift
@@ -61,6 +61,14 @@ final class MainViewController: NSViewController {
         // Publish
         if sender.title == "Publish" {
             sender.title = "Stop"
+
+            // Optional. If you don't specify; the frame size will be the current H264Encoder default of 480x272
+//            rtmpStream.videoSettings = [
+//                .profileLevel: kVTProfileLevel_H264_High_AutoLevel,
+//                .width: 1920,
+//                .height: 1280,
+//            ]
+            
             segmentedControl.isEnabled = false
             switch segmentedControl.selectedSegment {
             case 0:

--- a/Sources/Codec/H264Encoder.swift
+++ b/Sources/Codec/H264Encoder.swift
@@ -60,10 +60,17 @@ public final class H264Encoder {
         kCVPixelBufferOpenGLESCompatibilityKey: kCFBooleanTrue
     ]
     #else
-    static let defaultAttributes: [NSString: AnyObject] = [
-        kCVPixelBufferIOSurfacePropertiesKey: [:] as AnyObject,
-        kCVPixelBufferOpenGLCompatibilityKey: kCFBooleanTrue
-    ]
+        #if arch(arm64)
+        static var defaultAttributes: [NSString: AnyObject] = [
+            kCVPixelBufferIOSurfacePropertiesKey: [:] as AnyObject,
+            kCVPixelBufferMetalCompatibilityKey: kCFBooleanTrue
+        ]
+        #else
+        static var defaultAttributes: [NSString: AnyObject] = [
+            kCVPixelBufferIOSurfacePropertiesKey: [:] as AnyObject,
+            kCVPixelBufferOpenGLCompatibilityKey: kCFBooleanTrue
+        ]
+        #endif
     #endif
 
     public var settings: Setting<H264Encoder, Option> = [:] {
@@ -179,7 +186,11 @@ public final class H264Encoder {
         ]
 #if os(OSX)
         if enabledHardwareEncoder {
+            #if arch(arm64)
+            properties[kVTVideoEncoderSpecification_EncoderID] = "com.apple.videotoolbox.videoencoder.ave.avc" as NSObject
+            #else
             properties[kVTVideoEncoderSpecification_EncoderID] = "com.apple.videotoolbox.videoencoder.h264.gva" as NSObject
+            #endif
             properties["EnableHardwareAcceleratedVideoEncoder"] = kCFBooleanTrue
             properties["RequireHardwareAcceleratedVideoEncoder"] = kCFBooleanTrue
         }


### PR DESCRIPTION
… buffer attributes. Also set correct H264 encoder type for arm64 architecture.

Tested on M1, but not tested any other iOS/other apps on same platform.
Works without setting videoSettings in the demo app, and also if you do so.
