### PR TITLE
Add new directory to Package.swift.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,8 @@ let package = Package(
                     "PiP",
                     "RTMP",
                     "Util",
-                    "Platforms"
+                    "Platforms",
+                    "TS"
                 ])
     ]
 )


### PR DESCRIPTION
Swift Package Manager misses one of the new directories during installation of the latest commit, add it to Package.swift.

Tested on Xcode 12.4 using SPM installation.