### PR TITLE
Error in Xcode 12.5 Canvas (SwiftUI)

### DIFF
--- a/Sources/Net/NetSocket.CircularBuffer.swift
+++ b/Sources/Net/NetSocket.CircularBuffer.swift
@@ -45,7 +45,8 @@ extension NetSocket {
                 self.locked = locked
             }
             let length = min(count, capacity - tail)
-            return self.data.withUnsafeMutableBytes { (bytes: UnsafeMutableRawBufferPointer) -> Bool in
+            let selfData = self.data
+            return selfData.withUnsafeMutableBytes { (bytes: UnsafeMutableRawBufferPointer) -> Bool in
                 guard let pointer = bytes.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
                     return false
                 }

--- a/Sources/Net/NetSocket.CircularBuffer.swift
+++ b/Sources/Net/NetSocket.CircularBuffer.swift
@@ -45,7 +45,7 @@ extension NetSocket {
                 self.locked = locked
             }
             let length = min(count, capacity - tail)
-            let selfData = self.data
+            var selfData = self.data
             return selfData.withUnsafeMutableBytes { (bytes: UnsafeMutableRawBufferPointer) -> Bool in
                 guard let pointer = bytes.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
                     return false


### PR DESCRIPTION
It shows an error in SwiftUI canvas. This change fixes the error.
`overlapping accesses to 'self.data', but modification requires exclusive access; consider copying to a local variable`