### PR TITLE
Update Package.swift to require tvOS 10.2 or higher

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "HaishinKit",
     platforms: [
         .iOS(.v9),
-        .tvOS(.v10),
+        .tvOS(.v10_2),
         .macOS(.v10_11)
     ],
     products: [


### PR DESCRIPTION
Update the Swift package file to correctly specify the minimum version in MARKDOWN.md. Solves #896 