### PR TITLE
fix: render view x origin when using isMirrored option with MTHKView

### DIFF
--- a/Sources/Media/MTHKView.swift
+++ b/Sources/Media/MTHKView.swift
@@ -114,8 +114,6 @@ extension MTHKView: MTKViewDelegate {
         }
         let bounds = CGRect(origin: .zero, size: drawableSize)
         var scaledImage: CIImage = displayImage
-            .transformed(by: CGAffineTransform(translationX: translationX, y: translationY))
-            .transformed(by: CGAffineTransform(scaleX: scaleX, y: scaleY))
 
         if isMirrored {
             if #available(iOS 11.0, tvOS 11.0, macOS 10.13, *) {
@@ -124,6 +122,10 @@ extension MTHKView: MTKViewDelegate {
                 scaledImage = scaledImage.oriented(forExifOrientation: 2)
             }
         }
+
+        scaledImage = scaledImage
+            .transformed(by: CGAffineTransform(translationX: translationX, y: translationY))
+            .transformed(by: CGAffineTransform(scaleX: scaleX, y: scaleY))
 
         context.render(scaledImage, to: currentDrawable.texture, commandBuffer: commandBuffer, bounds: bounds, colorSpace: colorSpace)
         commandBuffer.present(currentDrawable)


### PR DESCRIPTION
When using MTHKView with _resizeAspectFill_ videoGravity, the x origin is set incorrectly with the _isMirrored_ option (tested on iPad Pro landscape).
Applying the mirror effect before resizing the image fixes the issue.

![Screen Shot 2021-09-07 at 16 52 51](https://user-images.githubusercontent.com/5812371/132370799-9ada0908-fa0a-4ecc-aab5-4c2256ec1b5d.png)
