### PR TITLE
Fix macOS example app type name violation build error 

### DIFF
--- a/Examples/iOSSwiftUI/iOSSwiftUIApp.swift
+++ b/Examples/iOSSwiftUI/iOSSwiftUIApp.swift
@@ -2,6 +2,7 @@ import HaishinKit
 import SwiftUI
 
 @main
+// swiftlint:disable type_name
 struct iOSSwiftUIApp: App {
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
Disabled SwiftLint type name check in `iOSSwiftUIApp.swift` to allow macOS app to build

<img width="735" alt="Xnip2021-10-24_16-35-41" src="https://user-images.githubusercontent.com/35972055/138612003-b9926700-e368-4045-aa7d-9efbf41cbd41.png">
