### PR TITLE
fix html was not rendered in Safari

### DIFF
--- a/Sources/HTTP/HLSService.swift
+++ b/Sources/HTTP/HLSService.swift
@@ -35,6 +35,7 @@ open class HLSService: HTTPService {
 
         switch request.uri {
         case "/":
+            response.statusCode = HTTPStatusCode.ok.description
             response.headerFields["Content-Type"] = "text/html"
             response.body = Data(document.utf8)
             client.doOutput(data: response.data)


### PR DESCRIPTION
## 概要
`HLSService`を利用して立てたiPhone上のWebサーバーのルートドキュメントにmacOSのSafariでアクセスすると、`HTTPService#defaultDocument`のhtmlがhtmlレンダリングされない不具合を見つけました。

<img width="500" alt="スクリーンショット 2021-11-16 23 56 44" src="https://user-images.githubusercontent.com/12999381/142012269-4cfb14b5-e946-4a36-b983-a446a6a9f95f.png">

### 再現環境
- macOS Big Sur バージョン 11.6
   Safari バージョン15.0 (16612.1.29.41.4, 16612)
- Xcode13.1
- iPhone 12 Pro iOS 15.1
- コード
  ![スクリーンショット 2021-11-17 0 10 35](https://user-images.githubusercontent.com/12999381/142011294-568cb7fa-d77c-4cf7-b642-d4d3325275a1.png)

## 修正
[RFC 7230](https://triple-underscore.github.io/RFC7230-ja.html#p.status-line)に基づいて、ステータスコードを返却するように修正。

### テスト
- Safari
  <img width="500" alt="スクリーンショット 2021-11-17 0 08 44" src="https://user-images.githubusercontent.com/12999381/142012460-659ffdda-39db-48e0-8b3c-aeb121c7b61f.png">
- Chrome
 ![スクリーンショット 2021-11-17 0 28 10](https://user-images.githubusercontent.com/12999381/142014625-55c720c5-21ee-4411-a4a7-6df7047edc80.png)

