### PR TITLE
overridden defaultDocument to be used

### DIFF
--- a/Sources/HTTP/HTTPService.swift
+++ b/Sources/HTTP/HTTPService.swift
@@ -182,7 +182,9 @@ open class HTTPService: NetService {
 """
     }
 
-    var document: String = HTTPService.defaultDocument
+    var document: String {
+        Self.defaultDocument
+    }
 
     func client(inputBuffer client: NetClient) {
         guard let request = HTTPRequest(data: client.inputBuffer) else {


### PR DESCRIPTION
## 概要
`HLSService`のサブクラスで`HLSService#defaultDocument`をオーバーライドできるが、superクラス側が使用されてしまうため、オーバーライド側が使用されるように変更しました。

## 再現環境
- コード
  ![スクリーンショット 2021-11-18 0 19 44](https://user-images.githubusercontent.com/12999381/142228330-27f2556e-fabf-4600-8d7f-095423291022.png) 
- 事象
  ![スクリーンショット 2021-11-17 23 13 48](https://user-images.githubusercontent.com/12999381/142228100-e5d2fac5-2566-4794-8bd7-3f16d75caf90.png)

## 修正テスト結果
![スクリーンショット 2021-11-17 23 15 45](https://user-images.githubusercontent.com/12999381/142228502-cd68982a-7754-4be2-8799-8337dbc0fec0.png)
