### PR TITLE
fix Video.js fails to parse duration in a playlist

### DIFF
--- a/Sources/HTTP/M3U.swift
+++ b/Sources/HTTP/M3U.swift
@@ -18,12 +18,12 @@ extension M3U: CustomStringConvertible {
     var description: String {
         var lines: [String] = [
             "#EXTM3U",
-            "#EXT-X-VERSION: \(version)",
-            "#EXT-X-MEDIA-SEQUENCE: \(mediaSequence)",
-            "#EXT-X-TARGETDURATION: \(Int(targetDuration))"
+            "#EXT-X-VERSION:\(version)",
+            "#EXT-X-MEDIA-SEQUENCE:\(mediaSequence)",
+            "#EXT-X-TARGETDURATION:\(Int(targetDuration))"
         ]
         for info in mediaList {
-            lines.append("#EXTINF: \(info.duration),")
+            lines.append("#EXTINF:\(info.duration),")
             lines.append(info.url.pathComponents.last!)
         }
         return lines.joined(separator: "\r\n")


### PR DESCRIPTION
## 概要
`HLSService`クラスが生成したプレイリストに[Video.js](https://videojs.com/)でアクセスすると、`duration`の解析に失敗し、映像が表示されない。

![スクリーンショット 2021-11-19 0 04 44](https://user-images.githubusercontent.com/12999381/142442747-7bce49ab-f8a5-497f-a3da-c93b6f21af11.png)

## 再現コード

<details>
<summary>アプリコード</summary>

```
class ViewController: UIViewController {
    
    let stream = HTTPStream()
    let service = HLSService(
        domain: "local",
        type: HTTPService.type,
        name: "",
        port: 80
    )

    override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(animated)

        switch AVCaptureDevice.authorizationStatus(for: .video) {
        case .notDetermined:
            Task {
                if await AVCaptureDevice.requestAccess(for: .video) {
                    setup()
                }
            }
        case .authorized:
            setup()
        case .denied, .restricted:
            break
        @unknown default:
            fatalError("hoge")
        }
    }

    func setup() {
        service.addHTTPStream(stream)

        let deviceDiscoverySession = AVCaptureDevice.DiscoverySession(
            deviceTypes: [AVCaptureDevice.DeviceType.builtInWideAngleCamera],
            mediaType: AVMediaType.video,
            position: AVCaptureDevice.Position.back
        )

        if let device = deviceDiscoverySession.devices.first {
            stream.attachCamera(device)
        }

        stream.publish("camera")
        service.startRunning()
    }
}
```

</details>

<details>
<summary>ブラウザ側のHTML</summary>

```
<!DOCTYPE html>
<html>
<head>
  <meta charset="UTF-8" />
  <link href="https://vjs.zencdn.net/7.15.4/video-js.css" rel="stylesheet" />
</head>
<body>
  <video
    id="my-video"
    class="video-js"
    controls
    width="360"
    height="640"
    data-setup="{}"
  >
    <source src="http://XXX.XXX.XXX.XXX/camera/playlist.m3u8" type="application/x-mpegURL" />
  </video>

  <script src="https://vjs.zencdn.net/7.15.4/video.js"></script>
</body>
</html>
```

</details>

## 修正方法
[RFC 8216](https://tex2e.github.io/rfc-translater/html/rfc8216.html)の4.3.1. Basic Tagsの記載のフォーマットに合わせるように変更。

結果
![スクリーンショット 2021-11-19 0 08 22](https://user-images.githubusercontent.com/12999381/142443821-799951a0-0649-48dd-9a87-82f42c4dce85.png)


