### PR TITLE
fix Crash when closing RTMPNWSocket

### DIFF
--- a/Sources/RTMP/RTMPNWSocket.swift
+++ b/Sources/RTMP/RTMPNWSocket.swift
@@ -91,7 +91,9 @@ final class RTMPNWSocket: RTMPSocketCompatible {
         }
         readyState = .closing
         timeoutHandler?.cancel()
+        objc_sync_enter(self)
         connection = nil
+        objc_sync_exit(self)
     }
 
     @discardableResult
@@ -127,7 +129,9 @@ final class RTMPNWSocket: RTMPSocketCompatible {
                 self.totalBytesOut.mutate { $0 += Int64(data.count) }
                 self.queueBytesOut.mutate { $0 -= Int64(data.count) }
             }
+            objc_sync_enter(self)
             self.connection?.send(content: data, completion: sendCompletion)
+            objc_sync_exit(self)
         }
         return data.count
     }


### PR DESCRIPTION
## 概要
`RTMPConnection#requireNetworkFramework`を`true`で行ったライブ配信を閉じるときに、ごくまれにクラッシュすることがある

![名称未設定](https://user-images.githubusercontent.com/12999381/143264117-6aa2495d-9956-40b5-a301-28809c9ffd4a.jpg)

## 再現コード
こちらを実行し続けていると、ごくまれにクラッシュする
```
    var connection: RTMPConnection?
    var stream: RTMPStream?

    private func setup() {
        self.connection?.removeEventListener(Event.Name.rtmpStatus, selector: #selector(self.connectionDidReceiveEvent(_:)), observer: self)

        let connection = RTMPConnection()
        connection.requireNetworkFramework = true
        connection.addEventListener(Event.Name.rtmpStatus, selector: #selector(self.connectionDidReceiveEvent(_:)), observer: self)
        let stream = RTMPStream(connection: connection)
        
        self.connection = connection
        self.stream = stream

        let deviceDiscoverySession = AVCaptureDevice.DiscoverySession(
            deviceTypes: [AVCaptureDevice.DeviceType.builtInWideAngleCamera],
            mediaType: AVMediaType.video,
            position: AVCaptureDevice.Position.back
        )

        if let device = deviceDiscoverySession.devices.first {
            stream.attachCamera(device)
        }

        stream.lockQueue.async {
            DispatchQueue.main.async {
                connection.connect("XXXXXXXX")
            }
        }
    }

    @objc private func connectionDidReceiveEvent(_ notification: Notification) {
        let event = Event.from(notification)
        guard event.type == .rtmpStatus,
              let data = event.data as? [String: Any],
              let rawCode = data["code"] as? String else { return }
        
        if let netConnectionCode = RTMPConnection.Code(rawValue: rawCode) {
            if netConnectionCode == .connectSuccess {
                DispatchQueue.main.async { [weak self] in                    
                    self?.stream?.publish("XXXXX")
                }
            }
        } else if let netStreamCode = RTMPStream.Code(rawValue: rawCode) {
            if netStreamCode == .publishStart {
                let seconds = Int.random(in: 1000...3000)
                let interval = DispatchTimeInterval.milliseconds(seconds)
                DispatchQueue.main.asyncAfter(deadline: .now() + interval) { [weak self] in
                    self?.connection?.close()
                    self?.setup()
                }
            }
        }
    }
```

## 修正方法
`RTMPNWSocket#connection`へのアクセスを排他にして修正