### PR TITLE
Fix: encodeSampleBuffer do not render what is encoded

### DIFF
--- a/Platforms/iOS/HKView.swift
+++ b/Platforms/iOS/HKView.swift
@@ -46,7 +46,7 @@ open class HKView: UIView {
         }
     }
     var position: AVCaptureDevice.Position = .front
-    var currentSampleBuffer: CMSampleBuffer?
+    var currentImageBuffer: CVImageBuffer?
 
     private weak var currentStream: NetStream? {
         didSet {
@@ -96,7 +96,7 @@ open class HKView: UIView {
 
 extension HKView: NetStreamRenderer {
     // MARK: NetStreamRenderer
-    func enqueue(_ sampleBuffer: CMSampleBuffer?) {
+    func enqueue(_ sampleBuffer: CVImageBuffer?) {
     }
 }
 

--- a/Sources/Media/AVVideoIOUnit.swift
+++ b/Sources/Media/AVVideoIOUnit.swift
@@ -416,7 +416,7 @@ extension AVVideoIOUnit {
                 }
                 context?.render(image, to: imageBuffer ?? buffer)
             }
-            renderer?.enqueue(sampleBuffer)
+            renderer?.enqueue(imageBuffer ?? buffer)
         }
 
         encoder.encodeImageBuffer(
@@ -455,6 +455,9 @@ extension AVVideoIOUnit: AVCaptureVideoDataOutputSampleBufferDelegate {
 extension AVVideoIOUnit: VideoDecoderDelegate {
     // MARK: VideoDecoderDelegate
     func sampleOutput(video sampleBuffer: CMSampleBuffer) {
-        renderer?.enqueue(sampleBuffer)
+        guard let buffer: CVImageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
+            return
+        }
+        renderer?.enqueue(buffer)
     }
 }

--- a/Sources/Media/MTHKView.swift
+++ b/Sources/Media/MTHKView.swift
@@ -18,7 +18,7 @@ open class MTHKView: MTKView, NetStreamRenderer {
     var orientation: AVCaptureVideoOrientation = .portrait
     #endif
 
-    var currentSampleBuffer: CMSampleBuffer?
+    var currentImageBuffer: CVImageBuffer?
     let colorSpace: CGColorSpace = CGColorSpaceCreateDeviceRGB()
 
     private lazy var commandQueue: MTLCommandQueue? = {
@@ -84,12 +84,12 @@ extension MTHKView: MTKViewDelegate {
             let renderCommandEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: currentRenderPassDescriptor) {
             renderCommandEncoder.endEncoding()
         }
-        guard let imageBuffer = currentSampleBuffer?.imageBuffer else {
+        guard let imageBuffer = currentImageBuffer else {
             commandBuffer.present(currentDrawable)
             commandBuffer.commit()
             return
         }
-        let displayImage = CIImage(cvPixelBuffer: imageBuffer)
+        let displayImage = CIImage(cvImageBuffer: imageBuffer)
         var scaleX: CGFloat = 0
         var scaleY: CGFloat = 0
         var translationX: CGFloat = 0

--- a/Sources/Net/NetStreamRenderer.swift
+++ b/Sources/Net/NetStreamRenderer.swift
@@ -16,17 +16,17 @@ protocol NetStreamRenderer: AnyObject {
     var orientation: AVCaptureVideoOrientation { get set }
     var position: AVCaptureDevice.Position { get set }
 #endif
-    var currentSampleBuffer: CMSampleBuffer? { get set }
+    var currentImageBuffer: CVImageBuffer? { get set }
     var videoFormatDescription: CMVideoFormatDescription? { get }
 
     func attachStream(_ stream: NetStream?)
-    func enqueue(_ sampleBuffer: CMSampleBuffer?)
+    func enqueue(_ sampleBuffer: CVImageBuffer?)
 }
 
 extension NetStreamRenderer where Self: NetStreamRendererView {
-    func enqueue(_ sampleBuffer: CMSampleBuffer?) {
+    func enqueue(_ sampleBuffer: CVImageBuffer?) {
         if Thread.isMainThread {
-            currentSampleBuffer = sampleBuffer
+            currentImageBuffer = sampleBuffer
             #if os(macOS)
             self.needsDisplay = true
             #else


### PR DESCRIPTION
Hi, 

Playing with Effects, I found out that some effects was not rendered on mobile screen, but apply to the streamed video.

I propose this change use the same `imageBuffer ??  buffer` in the line 419 of [Sources/Media/AVVideoIOUnit.swift](https://github.com/shogo4405/HaishinKit.swift/compare/main...chatelgu:fix-preview-if-not-in-place?expand=1#diff-b8cbb74787769dd699b013d9eb733d871c9eb84c0bf818f0491d986e8eb5dcd4) than for the `encoder` and `recorder`.

By the way, I didn't get well why imageBuffer is not used if the effects does not change the size of the image.
