### PR TITLE
Remove RTMPStreamDelegate default implement.

### DIFF
--- a/Sources/RTMP/RTMPConnection.swift
+++ b/Sources/RTMP/RTMPConnection.swift
@@ -461,17 +461,17 @@ open class RTMPConnection: EventDispatcher {
             }
             if total == measureInterval - 1 {
                 for (_, stream) in streams {
-                    stream.delegate?.rtmpStream(stream, didPublishInsufficientBW: self)
+                    stream.delegate?.rtmpStream(stream, publishInsufficientBWOccured: self)
                 }
             } else if total == 0 {
                 for (_, stream) in streams {
-                    stream.delegate?.rtmpStream(stream, didPublishSufficientBW: self)
+                    stream.delegate?.rtmpStream(stream, publishSufficientBWOccured: self)
                 }
             }
             previousQueueBytesOut.removeFirst()
         }
         for (_, stream) in streams {
-            stream.delegate?.rtmpStream(stream, didStatics: self)
+            stream.delegate?.rtmpStream(stream, updatedStats: self)
         }
     }
 }

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -3,33 +3,19 @@ import AVFoundation
 /// The interface a RTMPStream uses to inform its delegate.
 public protocol RTMPStreamDelegate: AnyObject {
     /// Tells the receiver to publish insufficient bandwidth occured.
-    func rtmpStream(_ stream: RTMPStream, didPublishInsufficientBW connection: RTMPConnection)
+    func rtmpStream(_ stream: RTMPStream, publishInsufficientBWOccured connection: RTMPConnection)
     /// Tells the receiver to publish sufficient bandwidth occured.
-    func rtmpStream(_ stream: RTMPStream, didPublishSufficientBW connection: RTMPConnection)
+    func rtmpStream(_ stream: RTMPStream, publishSufficientBWOccured connection: RTMPConnection)
     /// Tells the receiver to playback an audio packet incoming.
     func rtmpStream(_ stream: RTMPStream, didOutput audio: AVAudioBuffer, presentationTimeStamp: CMTime)
     /// Tells the receiver to playback a video packet incoming.
     func rtmpStream(_ stream: RTMPStream, didOutput video: CMSampleBuffer)
     /// Tells the receiver to update statistics.
-    func rtmpStream(_ stream: RTMPStream, didStatics connection: RTMPConnection)
+    func rtmpStream(_ stream: RTMPStream, updatedStats connection: RTMPConnection)
     /// Tells the receiver to video codec error occured.
     func rtmpStream(_ stream: RTMPStream, videoCodecErrorOccurred error: VideoCodec.Error)
     /// Tells the receiver to the stream opend.
     func rtmpStreamDidClear(_ stream: RTMPStream)
-}
-
-public extension RTMPStreamDelegate {
-    func rtmpStream(_ stream: RTMPStream, didStatics connection: RTMPConnection) {
-    }
-
-    func rtmpStream(_ stream: RTMPStream, didOutput audio: AVAudioBuffer, presentationTimeStamp: CMTime) {
-    }
-
-    func rtmpStream(_ stream: RTMPStream, didOutput video: CMSampleBuffer) {
-    }
-
-    func rtmpStream(_ stream: RTMPStream, videoCodecErrorOccurred erorr: VideoCodec.Error) {
-    }
 }
 
 /// An object that provides the interface to control a one-way channel over a RtmpConnection.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- Rename a RTMPStreamDelegate
- Remove a RTMPStreamDelegate default implement.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

