### PR TITLE
Remove stop recording on stop publishing

### DIFF
--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -482,7 +482,6 @@ open class RTMPStream: NetStream {
         case .publishing:
             FCUnpublish()
             mixer.stopEncoding()
-            mixer.recorder.stopRunning()
         default:
             break
         }


### PR DESCRIPTION
Hello, 

Since this PR https://github.com/shogo4405/HaishinKit.swift/pull/1035 local recording is not really related with publishing. 

This PR let the user decide when the recording should be stopped. 

Goal : allow record even on a network cut 