### PR TITLE
Advanced B-Frame compatibility

### DIFF
--- a/Sources/RTMP/RTMPMuxer.swift
+++ b/Sources/RTMP/RTMPMuxer.swift
@@ -35,7 +35,7 @@ extension RTMPMuxer: AudioCodecDelegate {
     }
 
     func audioCodec(_ codec: AudioCodec, didOutput sample: UnsafeMutableAudioBufferListPointer, presentationTimeStamp: CMTime) {
-        let delta: Double = (audioTimeStamp == CMTime.zero ? 0 : presentationTimeStamp.seconds - audioTimeStamp.seconds) * 1000
+        let delta = (audioTimeStamp == CMTime.zero ? 0 : presentationTimeStamp.seconds - audioTimeStamp.seconds) * 1000
         guard let bytes = sample[0].mData, 0 < sample[0].mDataByteSize && 0 <= delta else {
             return
         }
@@ -67,9 +67,9 @@ extension RTMPMuxer: VideoCodecDelegate {
         if decodeTimeStamp == CMTime.invalid {
             decodeTimeStamp = presentationTimeStamp
         } else {
-            compositionTime = Int32((presentationTimeStamp.seconds - decodeTimeStamp.seconds) * 1000)
+            compositionTime = (videoTimeStamp == .zero) ? 0 : Int32((sampleBuffer.presentationTimeStamp.seconds - videoTimeStamp.seconds) * 1000)
         }
-        let delta: Double = (videoTimeStamp == CMTime.zero ? 0 : decodeTimeStamp.seconds - videoTimeStamp.seconds) * 1000
+        let delta = (videoTimeStamp == CMTime.zero ? 0 : decodeTimeStamp.seconds - videoTimeStamp.seconds) * 1000
         guard let data = sampleBuffer.dataBuffer?.data, 0 <= delta else {
             return
         }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
Fix invalid timestamps messages from ffplay
```
[flv @ 0x13b716e20] Negative cts, previous timestamps might be wrong.
[flv @ 0x13b716e20] Invalid timestamps stream=1, pts=3168, dts=3201, size=176
[flv @ 0x13b716e20] Invalid timestamps stream=1, pts=3235, dts=3268, size=158
[flv @ 0x13b716e20] Invalid timestamps stream=1, pts=3301, dts=3334, size=192
[flv @ 0x13b716e20] Invalid timestamps stream=1, pts=3368, dts=3401, size=273
```

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:
<img width="762" alt="スクリーンショット 2022-08-12 19 04 22" src="https://user-images.githubusercontent.com/810189/184452922-0f588a9b-9a75-4124-8945-193701b72310.png">

