### PR TITLE
Feature: Expose key frame reordering as an option

### DIFF
--- a/Sources/Codec/VideoCodec.swift
+++ b/Sources/Codec/VideoCodec.swift
@@ -57,6 +57,7 @@ public class VideoCodec {
         case maxKeyFrameIntervalDuration
         /// Specifies the scalingMode.
         case scalingMode
+        case keyFrameReordering
 
         public var keyPath: AnyKeyPath {
             switch self {
@@ -78,6 +79,8 @@ public class VideoCodec {
                 return \VideoCodec.scalingMode
             case .profileLevel:
                 return \VideoCodec.profileLevel
+            case .keyFrameReordering:
+                return \VideoCodec.keyFrameReordering
             }
         }
     }
@@ -165,6 +168,14 @@ public class VideoCodec {
             invalidateSession = true
         }
     }
+    var keyFrameReordering: Bool? = false {
+        didSet {
+            guard keyFrameReordering != oldValue else {
+                return
+            }
+            invalidateSession = true
+        }
+    }
     var locked: UInt32 = 0
     var lockQueue = DispatchQueue(label: "com.haishinkit.HaishinKit.VideoCodec.lock")
     var expectedFPS: Float64 = AVMixer.defaultFPS {
@@ -209,7 +220,7 @@ public class VideoCodec {
             kVTCompressionPropertyKey_AverageBitRate: Int(bitrate) as NSObject,
             kVTCompressionPropertyKey_ExpectedFrameRate: NSNumber(value: expectedFPS),
             kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration: NSNumber(value: maxKeyFrameIntervalDuration),
-            kVTCompressionPropertyKey_AllowFrameReordering: !isBaseline as NSObject,
+            kVTCompressionPropertyKey_AllowFrameReordering: (keyFrameReordering ?? !isBaseline) as NSObject,
             kVTCompressionPropertyKey_PixelTransferProperties: [
                 "ScalingMode": scalingMode.rawValue
             ] as NSObject


### PR DESCRIPTION
## Description & motivation

Using b-frames can have a significant impact on streaming latency, exposed an option to allow disable this independently of the profile used.
Keeping the existing behaviour of disabling for baseline profiles but allowing it to be disabled in other profiles as well.

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
