### PR TITLE
Fix: session is reinitialized every frame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ soe/AIR_readme.txt
 Cartfile.resolved
 Carthage/*
 
+.idea/
+
 Package.resolved
 HaishinKit.xcodeproj/project.xcworkspace/xcuserdata/shogo.xcuserdatad/WorkspaceSettings.xcsettings
 *.xcsettings

--- a/Sources/Codec/VTSessionMode.swift
+++ b/Sources/Codec/VTSessionMode.swift
@@ -26,6 +26,10 @@ enum VTSessionMode {
                 return nil
             }
             status = session.setOptions(videoCodec.options())
+            guard status == noErr else {
+                videoCodec.delegate?.videoCodec(videoCodec, errorOccurred: .failedToPrepare(status: status))
+                return nil
+            }
             status = session.prepareToEncodeFrames()
             guard status == noErr else {
                 videoCodec.delegate?.videoCodec(videoCodec, errorOccurred: .failedToPrepare(status: status))

--- a/Sources/Codec/VideoCodec.swift
+++ b/Sources/Codec/VideoCodec.swift
@@ -237,6 +237,7 @@ public class VideoCodec {
     private var session: VTSessionConvertible? {
         didSet {
             oldValue?.invalidate()
+            invalidateSession = false
         }
     }
     private var invalidateSession = true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation

`VideoCodec` never sets `invalidateSession` to `false`. As result, `session` is reinitialized after every `inputBuffer` call.

Some misc updates:
* Add AppCode folder to .gitignore
* Check status after setting video codec options and call appropriate delegate method

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

