### PR TITLE
Bring back scaling mode setting

### DIFF
--- a/Sources/Codec/VideoCodec.swift
+++ b/Sources/Codec/VideoCodec.swift
@@ -335,7 +335,10 @@ public class VideoCodec {
             .init(key: .averageBitRate, value: NSNumber(value: bitrate)),
             .init(key: .expectedFrameRate, value: NSNumber(value: expectedFrameRate)),
             .init(key: .maxKeyFrameIntervalDuration, value: NSNumber(value: maxKeyFrameIntervalDuration)),
-            .init(key: .allowFrameReordering, value: (allowFrameReordering ?? !isBaseline) as NSObject)
+            .init(key: .allowFrameReordering, value: (allowFrameReordering ?? !isBaseline) as NSObject),
+            .init(key: .pixelTransferProperties, value: [
+                "ScalingMode": scalingMode.rawValue
+            ] as NSObject),
         ])
         #if os(OSX)
         if enabledHardwareEncoder {


### PR DESCRIPTION
## Description & motivation

`scalingMode` isn't used at the moment. This PR brings it back from older version of HaishinKit

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
