### PR TITLE
Remove DeviceUtil#device method.

### DIFF
--- a/Examples/iOS/LiveViewController.swift
+++ b/Examples/iOS/LiveViewController.swift
@@ -59,7 +59,7 @@ final class LiveViewController: UIViewController {
         rtmpStream.attachAudio(AVCaptureDevice.default(for: .audio)) { error in
             logger.warn(error.description)
         }
-        rtmpStream.attachCamera(DeviceUtil.device(withPosition: currentPosition)) { error in
+        rtmpStream.attachCamera(AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: currentPosition)) { error in
             logger.warn(error.description)
         }
         rtmpStream.addObserver(self, forKeyPath: "currentFPS", options: .new, context: nil)
@@ -81,7 +81,7 @@ final class LiveViewController: UIViewController {
         logger.info("rotateCamera")
         let position: AVCaptureDevice.Position = currentPosition == .back ? .front : .back
         rtmpStream.captureSettings[.isVideoMirrored] = position == .front
-        rtmpStream.attachCamera(DeviceUtil.device(withPosition: position)) { error in
+        rtmpStream.attachCamera(AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: position)) { error in
             logger.warn(error.description)
         }
         currentPosition = position
@@ -223,7 +223,7 @@ final class LiveViewController: UIViewController {
 
     @objc
     private func didBecomeActive(_ notification: Notification) {
-        rtmpStream.attachCamera(DeviceUtil.device(withPosition: currentPosition)) { error in
+        rtmpStream.attachCamera(AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: currentPosition)) { error in
             logger.warn(error.description)
         }
     }

--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ Real Time Messaging Protocol (RTMP).
 ```swift
 let rtmpConnection = RTMPConnection()
 let rtmpStream = RTMPStream(connection: rtmpConnection)
-rtmpStream.attachAudio(AVCaptureDevice.default(for: AVMediaType.audio)) { error in
+rtmpStream.attachAudio(AVCaptureDevice.default(for: .audio)) { error in
     // print(error)
 }
-rtmpStream.attachCamera(DeviceUtil.device(withPosition: .back)) { error in
+rtmpStream.attachCamera(AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back)) { error in
     // print(error)
 }
 
@@ -236,7 +236,7 @@ rtmpStream.recorderSettings = [
 ]
 
 // 2nd arguemnt set false
-rtmpStream.attachAudio(AVCaptureDevice.default(for: AVMediaType.audio), automaticallyConfiguresApplicationAudioSession: false)
+rtmpStream.attachAudio(AVCaptureDevice.default(for: .audio), automaticallyConfiguresApplicationAudioSession: false)
 
 ```
 ### Authentication
@@ -257,8 +257,8 @@ rtmpStream.attachScreen(AVCaptureScreenInput(displayID: CGMainDisplayID()))
 HTTP Live Streaming (HLS). Your iPhone/Mac become a IP Camera. Basic snipet. You can see http://ip.address:8080/hello/playlist.m3u8 
 ```swift
 var httpStream = HTTPStream()
-httpStream.attachCamera(DeviceUtil.device(withPosition: .back))
-httpStream.attachAudio(AVCaptureDevice.defaultDevice(withMediaType: AVMediaTypeAudio))
+httpStream.attachCamera(AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back))
+httpStream.attachAudio(AVCaptureDevice.default(for: .audio))
 httpStream.publish("hello")
 
 var hkView = HKView(frame: view.bounds)

--- a/Sources/Util/DeviceUtil.swift
+++ b/Sources/Util/DeviceUtil.swift
@@ -45,13 +45,6 @@ extension AVCaptureDevice {
 
 /// The namespace of DeviceUtil.
 public enum DeviceUtil {
-    /// Lookup device by position.
-    public static func device(withPosition: AVCaptureDevice.Position) -> AVCaptureDevice? {
-        AVCaptureDevice.devices().first {
-            $0.hasMediaType(.video) && $0.position == withPosition
-        }
-    }
-
     /// Lookup device by localizedName and mediaType.
     public static func device(withLocalizedName: String, mediaType: AVMediaType) -> AVCaptureDevice? {
         AVCaptureDevice.devices().first {


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- Remove DdeviceUtil#device(withPosition: AVCaptureDevice.Position)
  - AVCaptureDevice.devices() method is deprecated.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

