### PR TITLE
Invert hasAudio and hasVideo values

### DIFF
--- a/Sources/Net/NetStream.swift
+++ b/Sources/Net/NetStream.swift
@@ -60,20 +60,20 @@ open class NetStream: NSObject {
     /// Specifies the hasAudio indicies whether no signal audio or not.
     public var hasAudio: Bool {
         get {
-            mixer.audioIO.muted
+            !mixer.audioIO.muted
         }
         set {
-            mixer.audioIO.muted = newValue
+            mixer.audioIO.muted = !newValue
         }
     }
 
     /// Specifies the hasVideo indicies whether freeze video signal or not.
     public var hasVideo: Bool {
         get {
-            mixer.videoIO.muted
+            !mixer.videoIO.muted
         }
         set {
-            mixer.videoIO.muted = newValue
+            mixer.videoIO.muted = !newValue
         }
     }
 


### PR DESCRIPTION
## Description & motivation

Invert `hasAudio` and `hasVideo` values to match "muted" flag 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

