### PR TITLE
Fix: add audio sample rate

### DIFF
--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -440,6 +440,7 @@ open class RTMPStream: NetStream {
         if mixer.audioIO.capture != nil {
             metadata["audiocodecid"] = FLVAudioCodec.aac.rawValue
             metadata["audiodatarate"] = mixer.audioIO.codec.bitrate / 1000
+            metadata["audiosamplerate"] = mixer.audioIO.codec.sampleRate
         }
         #endif
         return metadata


### PR DESCRIPTION
Fixes #1103

## Description & motivation
Providing audio sample rate is helpful for knowing what data is coming in the stream

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)