### PR TITLE
Support "rtmps" RTMPNWSocket without setPrameter option.

### DIFF
--- a/Sources/RTMP/RTMPNWSocket.swift
+++ b/Sources/RTMP/RTMPNWSocket.swift
@@ -18,7 +18,16 @@ final class RTMPNWSocket: RTMPSocketCompatible {
         }
     }
     var outputBufferSize: Int = RTMPNWSocket.defaultWindowSizeC
-    var securityLevel: StreamSocketSecurityLevel = .none
+    var securityLevel: StreamSocketSecurityLevel = .none {
+        didSet {
+            switch securityLevel {
+            case .ssLv2, .ssLv3, .tlSv1, .negotiatedSSL:
+                parameters = .tls
+            default:
+                parameters = .tcp
+            }
+        }
+    }
     var qualityOfService: DispatchQoS = .default
     var inputBuffer = Data()
     weak var delegate: RTMPSocketDelegate?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,5 +16,6 @@
 desc "[CI] Review PullRequest."
 lane :review do
   spm
+  carthage(use_xcframeworks: true)
   scan(scheme: 'Tests')
 end


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
* RTMPNWSocket 
  - Enabled SSL connection without option.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

