### PR TITLE
Can't playback rtmpStream.close() after rtmpStream.play().

### DIFF
--- a/Sources/Media/Choreographer.swift
+++ b/Sources/Media/Choreographer.swift
@@ -18,7 +18,8 @@ protocol Choreographer: Running {
 }
 
 final class DisplayLinkChoreographer: NSObject, Choreographer {
-    static let defaultPreferredFramesPerSecond = 0
+    private static let duration = 0.0
+    private static let preferredFramesPerSecond = 0
 
     var isPaused: Bool {
         get {
@@ -30,7 +31,7 @@ final class DisplayLinkChoreographer: NSObject, Choreographer {
     }
     weak var delegate: ChoreographerDelegate?
     var isRunning: Atomic<Bool> = .init(false)
-    private var duration: Double = 0.0
+    private var duration: Double = DisplayLinkChoreographer.duration
     private var displayLink: DisplayLink? {
         didSet {
             oldValue?.invalidate()
@@ -38,13 +39,13 @@ final class DisplayLinkChoreographer: NSObject, Choreographer {
                 return
             }
             displayLink.isPaused = true
-            displayLink.preferredFramesPerSecond = Self.defaultPreferredFramesPerSecond
+            displayLink.preferredFramesPerSecond = Self.preferredFramesPerSecond
             displayLink.add(to: .main, forMode: .common)
         }
     }
 
     func clear() {
-        duration = 0.0
+        duration = Self.duration
     }
 
     @objc
@@ -62,7 +63,7 @@ extension DisplayLinkChoreographer: Running {
 
     func stopRunning() {
         displayLink = nil
-        duration = 0.0
+        duration = DisplayLinkChoreographer.duration
         isRunning.mutate { $0 = false }
     }
 }

--- a/Sources/Media/MediaLink.swift
+++ b/Sources/Media/MediaLink.swift
@@ -10,7 +10,8 @@ protocol MediaLinkDelegate: AnyObject {
 }
 
 final class MediaLink {
-    static let defaultBufferTime: Double = 0.2
+    private static let bufferTime = 0.2
+    private static let bufferingTime = 0.0
 
     var isPaused = false {
         didSet {
@@ -27,9 +28,9 @@ final class MediaLink {
         }
     }
     var hasVideo = false
-    var bufferTime = MediaLink.defaultBufferTime
+    var bufferTime = MediaLink.bufferTime
     weak var delegate: MediaLinkDelegate?
-    lazy var playerNode = AVAudioPlayerNode()
+    private(set) lazy var playerNode = AVAudioPlayerNode()
     private(set) var isRunning: Atomic<Bool> = .init(false)
     private var buffer: RingBuffer<CMSampleBuffer> = .init(256)
     private var isBuffering = true {
@@ -41,7 +42,7 @@ final class MediaLink {
             delegate?.mediaLink(self, didBufferingChanged: isBuffering)
         }
     }
-    private var bufferingTime: Double = 0.0
+    private var bufferingTime = MediaLink.bufferingTime
     private lazy var choreographer: Choreographer = {
         var choreographer = DisplayLinkChoreographer()
         choreographer.delegate = self
@@ -132,7 +133,8 @@ extension MediaLink: Running {
                 return
             }
             self.hasVideo = false
-            self.bufferingTime = Self.defaultBufferTime
+            self.bufferingTime = Self.bufferingTime
+            self.isBuffering = true
             self.choreographer.startRunning()
             self.isRunning.mutate { $0 = true }
         }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- Fix can't playback rtmpStream.play() -> rtmpStream.close() -> rtmpStream.play().

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

