### PR TITLE
Set a device frameRate when unsupportedDeviceActiveFormat.

### DIFF
--- a/Sources/Media/IOCaptureUnit.swift
+++ b/Sources/Media/IOCaptureUnit.swift
@@ -161,13 +161,13 @@ public class IOVideoCaptureUnit: IOCaptureUnit {
     }
 
     func setFrameRate(_ frameRate: Float64) {
-        guard let device, let data = device.actualFPS(frameRate) else {
+        guard let device, let duration = device.activeFormat.getFrameRate(frameRate) else {
             return
         }
         do {
             try device.lockForConfiguration()
-            device.activeVideoMinFrameDuration = data.duration
-            device.activeVideoMaxFrameDuration = data.duration
+            device.activeVideoMinFrameDuration = duration
+            device.activeVideoMaxFrameDuration = duration
             device.unlockForConfiguration()
         } catch {
             logger.error("while locking device for fps:", error)

--- a/Sources/Media/IOMixer.swift
+++ b/Sources/Media/IOMixer.swift
@@ -274,6 +274,10 @@ extension IOMixer: Running {
             do {
                 try device.lockForConfiguration()
                 device.activeFormat = format
+                if let duration = format.getFrameRate(videoIO.frameRate) {
+                    device.activeVideoMinFrameDuration = duration
+                    device.activeVideoMaxFrameDuration = duration
+                }
                 device.unlockForConfiguration()
                 session.startRunning()
             } catch {

--- a/Sources/Util/DeviceUtil.swift
+++ b/Sources/Util/DeviceUtil.swift
@@ -6,39 +6,32 @@ extension AVFrameRateRange {
         max(minFrameRate, min(maxFrameRate, rate))
     }
 
-    func contains(rate: Float64) -> Bool {
-        (minFrameRate...maxFrameRate) ~= rate
+    func contains(frameRate: Float64) -> Bool {
+        (minFrameRate...maxFrameRate) ~= frameRate
     }
 }
 
-extension AVCaptureDevice {
-    func actualFPS(_ fps: Float64) -> (fps: Float64, duration: CMTime)? {
+extension AVCaptureDevice.Format {
+    func getFrameRate(_ frameRate: Float64) -> CMTime? {
         var durations: [CMTime] = []
         var frameRates: [Float64] = []
-
-        for range in activeFormat.videoSupportedFrameRateRanges {
+        for range in videoSupportedFrameRateRanges {
             if range.minFrameRate == range.maxFrameRate {
                 durations.append(range.minFrameDuration)
                 frameRates.append(range.maxFrameRate)
                 continue
             }
-
-            if range.contains(rate: fps) {
-                return (fps, CMTimeMake(value: 100, timescale: Int32(100 * fps)))
+            if range.contains(frameRate: frameRate) {
+                return CMTimeMake(value: 100, timescale: Int32(100 * frameRate))
             }
-
-            let actualFPS: Float64 = range.clamp(rate: fps)
-            return (actualFPS, CMTimeMake(value: 100, timescale: Int32(100 * actualFPS)))
+            return CMTimeMake(value: 100, timescale: Int32(100 * range.clamp(rate: frameRate)))
         }
-
-        let diff = frameRates.map { abs($0 - fps) }
-
+        let diff = frameRates.map { abs($0 - frameRate) }
         if let minElement: Float64 = diff.min() {
             for i in 0..<diff.count where diff[i] == minElement {
-                return (frameRates[i], durations[i])
+                return durations[i]
             }
         }
-
         return nil
     }
 }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- Set a device frameRate when unsupportedDeviceActiveFormat.
  - It was not possible to set the expected value 30.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

