### PR TITLE
fixed RTMPStream.videoSettingsに設定した値がすぐにdefaultに上書きされる

### DIFF
--- a/Sources/Codec/VTSessionMode.swift
+++ b/Sources/Codec/VTSessionMode.swift
@@ -25,7 +25,7 @@ enum VTSessionMode {
                 videoCodec.delegate?.videoCodec(videoCodec, errorOccurred: .failedToCreate(status: status))
                 return nil
             }
-            status = session.setOptions(videoCodec.settings.options())
+            status = session.setOptions(videoCodec.settings.options(videoCodec))
             guard status == noErr else {
                 videoCodec.delegate?.videoCodec(videoCodec, errorOccurred: .failedToPrepare(status: status))
                 return nil

--- a/Sources/Codec/VideoCodec.swift
+++ b/Sources/Codec/VideoCodec.swift
@@ -61,6 +61,7 @@ public class VideoCodec {
     public private(set) var isRunning: Atomic<Bool> = .init(false)
 
     var lockQueue = DispatchQueue(label: "com.haishinkit.HaishinKit.VideoCodec.lock")
+    var expectedFrameRate = IOMixer.defaultFrameRate
     var formatDescription: CMFormatDescription? {
         didSet {
             guard !CMFormatDescriptionEqual(formatDescription, otherFormatDescription: oldValue) else {

--- a/Sources/Codec/VideoCodecSettings.swift
+++ b/Sources/Codec/VideoCodecSettings.swift
@@ -100,7 +100,6 @@ public struct VideoCodecSettings: Codable {
     public var isHardwareEncoderEnabled = true
 
     var format: Format = .h264
-    var expectedFrameRate: Float64 = IOMixer.defaultFrameRate
 
     /// Creates a new VideoCodecSettings instance.
     public init(
@@ -146,14 +145,14 @@ public struct VideoCodecSettings: Codable {
         }
     }
 
-    func options() -> Set<VTSessionOption> {
+    func options(_ codec: VideoCodec) -> Set<VTSessionOption> {
         let isBaseline = profileLevel.contains("Baseline")
         var options = Set<VTSessionOption>([
             .init(key: .realTime, value: kCFBooleanTrue),
             .init(key: .profileLevel, value: profileLevel as NSObject),
             .init(key: bitRateMode.key, value: NSNumber(value: bitRate)),
             // It seemes that VT supports the range 0 to 30.
-            .init(key: .expectedFrameRate, value: NSNumber(value: (expectedFrameRate <= 30) ? expectedFrameRate : 0)),
+            .init(key: .expectedFrameRate, value: NSNumber(value: (codec.expectedFrameRate <= 30) ? codec.expectedFrameRate : 0)),
             .init(key: .maxKeyFrameIntervalDuration, value: NSNumber(value: maxKeyFrameIntervalDuration)),
             .init(key: .allowFrameReordering, value: (allowFrameReordering ?? !isBaseline) as NSObject),
             .init(key: .pixelTransferProperties, value: [

--- a/Sources/Media/IOVideoUnit.swift
+++ b/Sources/Media/IOVideoUnit.swift
@@ -72,7 +72,6 @@ final class IOVideoUnit: NSObject, IOUnit {
             guard frameRate != oldValue else {
                 return
             }
-            codec.settings.expectedFrameRate = frameRate
             capture.setFrameRate(frameRate)
             multiCamCapture.setFrameRate(frameRate)
         }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- Fixed #1219

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

