### PR TITLE
fixed FPSがRTMPStream.frameRateに設定した値に関係なくRTMPStream.sessionPresetの値によって決まる

### DIFF
--- a/Sources/Codec/VideoCodecSettings.swift
+++ b/Sources/Codec/VideoCodecSettings.swift
@@ -151,14 +151,18 @@ public struct VideoCodecSettings: Codable {
             .init(key: .realTime, value: kCFBooleanTrue),
             .init(key: .profileLevel, value: profileLevel as NSObject),
             .init(key: bitRateMode.key, value: NSNumber(value: bitRate)),
-            // It seemes that VT supports the range 0 to 30.
-            .init(key: .expectedFrameRate, value: NSNumber(value: (codec.expectedFrameRate <= 30) ? codec.expectedFrameRate : 0)),
             .init(key: .maxKeyFrameIntervalDuration, value: NSNumber(value: maxKeyFrameIntervalDuration)),
             .init(key: .allowFrameReordering, value: (allowFrameReordering ?? !isBaseline) as NSObject),
             .init(key: .pixelTransferProperties, value: [
                 "ScalingMode": scalingMode.rawValue
             ] as NSObject)
         ])
+        if codec.expectedFrameRate != IOMixer.defaultFrameRate {
+            // It seemes that VT supports the range 0 to 30.
+            options.insert(.init(key: .expectedFrameRate, value: NSNumber(value: (codec.expectedFrameRate <= 30) ? codec.expectedFrameRate : 0)))
+        } else {
+            options.insert(.init(key: .expectedFrameRate, value: NSNumber(value: 30)))
+        }
         #if os(macOS)
         if isHardwareEncoderEnabled {
             options.insert(.init(key: .encoderID, value: format.encoderID))

--- a/Sources/Media/IOCaptureUnit.swift
+++ b/Sources/Media/IOCaptureUnit.swift
@@ -162,7 +162,7 @@ public class IOVideoCaptureUnit: IOCaptureUnit {
     }
 
     func setFrameRate(_ frameRate: Float64) {
-        guard let device else {
+        guard let device, 0 < frameRate else {
             return
         }
         do {

--- a/Sources/Media/IOMixer.swift
+++ b/Sources/Media/IOMixer.swift
@@ -6,6 +6,7 @@ import SwiftPMSupport
 #if os(iOS)
 import UIKit
 #endif
+
 #if os(iOS) || os(macOS)
 extension AVCaptureSession.Preset {
     static let `default`: AVCaptureSession.Preset = .hd1280x720
@@ -24,12 +25,12 @@ protocol IOMixerDelegate: AnyObject {
 
 /// An object that mixies audio and video for streaming.
 public class IOMixer {
-    /// The default fps for an IOMixer, value is 30.
-    public static let defaultFrameRate: Float64 = 30
     /// The AVAudioEngine shared instance holder.
     public static let audioEngineHolder: InstanceHolder<AVAudioEngine> = .init {
         return AVAudioEngine()
     }
+
+    static let defaultFrameRate: Float64 = -1
 
     enum MediaSync {
         case video

--- a/Sources/Net/NetStream.swift
+++ b/Sources/Net/NetStream.swift
@@ -78,13 +78,14 @@ open class NetStream: NSObject {
     /// Specifies the frame rate of a device capture.
     public var frameRate: Float64 {
         get {
-            var frameRate: Float64 = IOMixer.defaultFrameRate
+            var frameRate = IOMixer.defaultFrameRate
             lockQueue.sync {
                 frameRate = self.mixer.videoIO.frameRate
             }
             return frameRate
         }
         set {
+            precondition(0 < newValue)
             lockQueue.async {
                 self.mixer.videoIO.frameRate = newValue
             }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- fixed #1220

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

