### PR TITLE
fixed VTDecompressionSessionDecodeFrame fails with OSStatus=-12909 #57

### DIFF
--- a/Sources/MPEG/PacketizedElementaryStream.swift
+++ b/Sources/MPEG/PacketizedElementaryStream.swift
@@ -327,13 +327,15 @@ struct PacketizedElementaryStream: PESPacketHeader {
     }
 
     mutating func makeSampleBuffer(_ streamType: ESStreamType, previousPresentationTimeStamp: CMTime, formatDescription: CMFormatDescription?) -> CMSampleBuffer? {
-        let blockBuffer = data.makeBlockBuffer(advancedBy: 0)
+        var blockBuffer: CMBlockBuffer? = nil
         var sampleSizes: [Int] = []
         switch streamType {
         case .h264:
             _ = AVCFormatStream.toNALFileFormat(&data)
+            blockBuffer = data.makeBlockBuffer(advancedBy: 0)
             sampleSizes.append(blockBuffer?.dataLength ?? 0)
         case .adtsAac:
+            blockBuffer = data.makeBlockBuffer(advancedBy: 0)
             let reader = ADTSReader()
             reader.read(data)
             var iterator = reader.makeIterator()

--- a/Sources/Media/IOMixer.swift
+++ b/Sources/Media/IOMixer.swift
@@ -183,7 +183,7 @@ public class IOMixer {
                 audioIO.codec.appendSampleBuffer(sampleBuffer)
             case kCMMediaType_Video:
                 videoIO.codec.formatDescription = sampleBuffer.formatDescription
-                mediaLink.enqueueVideo(sampleBuffer)
+                videoIO.codec.appendSampleBuffer(sampleBuffer)
             default:
                 break
             }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- fixed https://github.com/shogo4405/SRTHaishinKit.swift/issues/57

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

