### PR TITLE
fixed break audio with stereo format.

### DIFF
--- a/Sources/Codec/AudioCodecRingBuffer.swift
+++ b/Sources/Codec/AudioCodecRingBuffer.swift
@@ -86,11 +86,11 @@ final class AudioCodecRingBuffer {
             let channelCount = Int(format.channelCount)
             switch format.commonFormat {
             case .pcmFormatInt16:
-                memcpy(current.int16ChannelData?[0].advanced(by: index), workingBuffer.int16ChannelData?[0].advanced(by: offset), numSamples * 2 * channelCount)
+                memcpy(current.int16ChannelData?[0].advanced(by: index * channelCount), workingBuffer.int16ChannelData?[0].advanced(by: offset * channelCount), numSamples * 2 * channelCount)
             case .pcmFormatInt32:
-                memcpy(current.int32ChannelData?[0].advanced(by: index), workingBuffer.int32ChannelData?[0].advanced(by: offset), numSamples * 4 * channelCount)
+                memcpy(current.int32ChannelData?[0].advanced(by: index * channelCount), workingBuffer.int32ChannelData?[0].advanced(by: offset * channelCount), numSamples * 4 * channelCount)
             case .pcmFormatFloat32:
-                memcpy(current.floatChannelData?[0].advanced(by: index), workingBuffer.floatChannelData?[0].advanced(by: offset), numSamples * 4 * channelCount)
+                memcpy(current.floatChannelData?[0].advanced(by: index * channelCount), workingBuffer.floatChannelData?[0].advanced(by: offset * channelCount), numSamples * 4 * channelCount)
             default:
                 break
             }

--- a/Tests/Codec/AudioCodecBufferTests.swift
+++ b/Tests/Codec/AudioCodecBufferTests.swift
@@ -5,7 +5,7 @@ import AVFoundation
 @testable import HaishinKit
 
 final class AudioCodecBufferTests: XCTestCase {
-    func testMain() {
+    func testMonoSamples256_16bit() {
         guard
             let sampleBuffer = SinWaveUtil.makeCMSampleBuffer(44100, numSamples: 256),
             var asbd = sampleBuffer.formatDescription?.audioStreamBasicDescription else {
@@ -29,7 +29,31 @@ final class AudioCodecBufferTests: XCTestCase {
         }
     }
 
-    func testMain2() {
+    func testStereoSamples256_16bit() {
+        guard
+            let sampleBuffer = SinWaveUtil.makeCMSampleBuffer(44100, numSamples: 256, channels: 2),
+            var asbd = sampleBuffer.formatDescription?.audioStreamBasicDescription else {
+            XCTFail()
+            return
+        }
+        let buffer = AudioCodecRingBuffer(&asbd, numSamples: 1024)
+        for _ in 0..<1024/256 {
+            _ = buffer?.appendSampleBuffer(sampleBuffer, offset: 0)
+        }
+        XCTAssertTrue(buffer?.isReady == true)
+        let sampleBufferData = (try? sampleBuffer.dataBuffer?.dataBytes()) ?? Data()
+        var expectedData = Data()
+        expectedData.append(sampleBufferData)
+        expectedData.append(sampleBufferData)
+        expectedData.append(sampleBufferData)
+        expectedData.append(sampleBufferData)
+        if let pointer = buffer?.current.int16ChannelData?[0] {
+            let data = Data(bytes: pointer, count: 1024 * 2 * 2)
+            XCTAssertEqual(expectedData, data)
+        }
+    }
+
+    func testMonoSamples920_921_16bit() {
         guard
             let sampleBuffer_1 = SinWaveUtil.makeCMSampleBuffer(44100, numSamples: 920),
             let sampleBuffer_2 = SinWaveUtil.makeCMSampleBuffer(44100, numSamples: 921),
@@ -70,7 +94,48 @@ final class AudioCodecBufferTests: XCTestCase {
         }
     }
 
-    func testMain3() {
+    func testStereoSamples920_921_16bit() {
+        guard
+            let sampleBuffer_1 = SinWaveUtil.makeCMSampleBuffer(44100, numSamples: 920, channels: 2),
+            let sampleBuffer_2 = SinWaveUtil.makeCMSampleBuffer(44100, numSamples: 921, channels: 2),
+            var asbd = sampleBuffer_1.formatDescription?.audioStreamBasicDescription,
+            let buffer = AudioCodecRingBuffer(&asbd, numSamples: 1024) else {
+            XCTFail()
+            return
+        }
+
+        let sampleBuffer_1Data = (try? sampleBuffer_1.dataBuffer?.dataBytes()) ?? Data()
+        let sampleBuffer_2Data = (try? sampleBuffer_2.dataBuffer?.dataBytes()) ?? Data()
+        var numBuffer = buffer.appendSampleBuffer(sampleBuffer_1, offset: 0)
+        numBuffer = buffer.appendSampleBuffer(sampleBuffer_2, offset: 0)
+
+        XCTAssertTrue(buffer.isReady)
+        if let pointer = buffer.current.int16ChannelData?[0] {
+            let data = Data(bytes: pointer, count: 1024 * 2 * 2)
+            var expectedData = Data()
+            expectedData.append(sampleBuffer_1Data)
+            expectedData.append(sampleBuffer_2Data.subdata(in: 0..<numBuffer * 2 * 2))
+            XCTAssertEqual(expectedData.bytes, data.bytes)
+        } else {
+            XCTFail()
+        }
+        buffer.next()
+        XCTAssertFalse(buffer.isReady)
+        XCTAssertEqual(numBuffer, 104)
+
+        var expectedData = Data()
+        expectedData.append(sampleBuffer_2Data.subdata(in: numBuffer * 2 * 2..<sampleBuffer_2Data.count))
+        numBuffer = buffer.appendSampleBuffer(sampleBuffer_2, offset: numBuffer)
+
+        if let pointer = buffer.current.int16ChannelData?[0] {
+            let data = Data(bytes: pointer, count: expectedData.count)
+            XCTAssertEqual(expectedData.bytes, data.bytes)
+        } else {
+            XCTFail()
+        }
+    }
+
+    func testMonoSamples920_921_16bit_2() {
         guard
             let sampleBuffer_1 = SinWaveUtil.makeCMSampleBuffer(44100, numSamples: 920),
             let sampleBuffer_2 = SinWaveUtil.makeCMSampleBuffer(44100, numSamples: 921),
@@ -86,6 +151,31 @@ final class AudioCodecBufferTests: XCTestCase {
 
         var expectedData = Data()
         expectedData.append(sampleBuffer_2Data.subdata(in: 104 * 2..<sampleBuffer_2Data.count))
+
+        if let pointer = buffer.current.int16ChannelData?[0] {
+            let data = Data(bytes: pointer, count: expectedData.count)
+            XCTAssertEqual(expectedData.bytes, data.bytes)
+        } else {
+            XCTFail()
+        }
+    }
+
+    func testStereoSamples920_921_16bit_2() {
+        guard
+            let sampleBuffer_1 = SinWaveUtil.makeCMSampleBuffer(44100, numSamples: 920, channels: 2),
+            let sampleBuffer_2 = SinWaveUtil.makeCMSampleBuffer(44100, numSamples: 921, channels: 2),
+            var asbd = sampleBuffer_1.formatDescription?.audioStreamBasicDescription,
+            let buffer = AudioCodecRingBuffer(&asbd, numSamples: 1024) else {
+            XCTFail()
+            return
+        }
+        let sampleBuffer_2Data = (try? sampleBuffer_2.dataBuffer?.dataBytes()) ?? Data()
+
+        appendSampleBuffer(buffer, sampleBuffer: sampleBuffer_1, offset: 0)
+        appendSampleBuffer(buffer, sampleBuffer: sampleBuffer_2, offset: 0)
+
+        var expectedData = Data()
+        expectedData.append(sampleBuffer_2Data.subdata(in: 104 * 2 * 2..<sampleBuffer_2Data.count))
 
         if let pointer = buffer.current.int16ChannelData?[0] {
             let data = Data(bytes: pointer, count: expectedData.count)


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
I have fixed the issue where the audio signal gets corrupted when capturing stereo audio and the sample count is less than 1024 during microphone capture.

- fixed #1208
- refs #1240

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:
<img width="1498" alt="スクリーンショット 2023-07-29 10 59 10" src="https://github.com/shogo4405/HaishinKit.swift/assets/810189/d8814322-6434-4072-bfe1-543a5402229f">

