### PR TITLE
fixed the statistical processing RTMPNWSocket.

### DIFF
--- a/Sources/RTMP/RTMPNWSocket.swift
+++ b/Sources/RTMP/RTMPNWSocket.swift
@@ -128,7 +128,7 @@ final class RTMPNWSocket: RTMPSocketCompatible {
 
     @discardableResult
     func doOutput(data: Data) -> Int {
-        queueBytesOut.mutate { $0 = Int64(data.count) }
+        queueBytesOut.mutate { $0 += Int64(data.count) }
         connection?.send(content: data, completion: .contentProcessed { error in
             guard self.connected else {
                 return


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- might be fixed https://github.com/shogo4405/HaishinKit.swift/issues/1210
- There was an error in the statistical processing, and instead of measuring at a 1-second interval as intended, it was being handled with the most recent enqueued data.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

