### PR TITLE
fixed the crash the order of detachCamera.

### DIFF
--- a/Sources/Media/IOVideoUnit.swift
+++ b/Sources/Media/IOVideoUnit.swift
@@ -163,7 +163,6 @@ final class IOVideoUnit: NSObject, IOUnit {
             return
         }
         guard let device else {
-            mixer.isMultiCamSessionEnabled = false
             mixer.session.beginConfiguration()
             defer {
                 mixer.session.commitConfiguration()


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
fixed the crash the order of method execution.
```
2023-08-16 00:28:53.202630+0900 Example iOS[41970:4745685] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[AVCaptureSession removeConnection:] <AVCaptureConnection: 0x281493da0> does not exist in this session'
*** First throw call stack:
(0x1cfd54cb4 0x1c8de83d0 0x1e9a0b228 0x1033a0068 0x103262510 0x10329d650 0x1032651e0 0x102dc4520 0x102dc6038 0x102dce0b0 0x102dcedf4 0x102ddbc74 0x22fb85ddc 0x22fb85b7c)
libc++abi: terminating due to uncaught exception of type NSException
```

**Reproduce**
```
rtmpStream.attachAudio(nil)
rtmpStream.attachCamera(nil)
if #available(iOS 13.0, *) {
  rtmpStream.attachMultiCamera(nil)
}
```
**Don't reproduce**
```
rtmpStream.attachAudio(nil)
if #available(iOS 13.0, *) {
  rtmpStream.attachMultiCamera(nil)
}
rtmpStream.attachCamera(nil)
```

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

