### PR TITLE
Support for multi-channel audio streaming

### DIFF
--- a/HaishinKit.xcodeproj/project.pbxproj
+++ b/HaishinKit.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		035AFA042263868E009DD0BB /* RTMPStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035AFA032263868E009DD0BB /* RTMPStreamTests.swift */; };
+		1A21630C73D792376BBCFC7D /* AVAudioFormat+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2166D3A449D813866FE9D9 /* AVAudioFormat+Extension.swift */; };
+		1A216A40B7F375BC52D193CC /* AVAudioFormat+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2166D3A449D813866FE9D9 /* AVAudioFormat+Extension.swift */; };
+		1A216F07B0BD8E05C8ECC8F1 /* AVAudioFormat+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2166D3A449D813866FE9D9 /* AVAudioFormat+Extension.swift */; };
 		2901A4EE1D437170002BBD23 /* MediaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2901A4ED1D437170002BBD23 /* MediaLink.swift */; };
 		2901A4EF1D437662002BBD23 /* MediaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2901A4ED1D437170002BBD23 /* MediaLink.swift */; };
 		290686031DFDB7A7008EB7ED /* RTMPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290686021DFDB7A6008EB7ED /* RTMPConnectionTests.swift */; };
@@ -593,6 +596,7 @@
 
 /* Begin PBXFileReference section */
 		035AFA032263868E009DD0BB /* RTMPStreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RTMPStreamTests.swift; sourceTree = "<group>"; };
+		1A2166D3A449D813866FE9D9 /* AVAudioFormat+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVAudioFormat+Extension.swift"; sourceTree = "<group>"; };
 		2901A4ED1D437170002BBD23 /* MediaLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLink.swift; sourceTree = "<group>"; };
 		290686021DFDB7A6008EB7ED /* RTMPConnectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RTMPConnectionTests.swift; sourceTree = "<group>"; };
 		290EA88E1DFB616000053022 /* Foundation+ExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Foundation+ExtensionTests.swift"; sourceTree = "<group>"; };
@@ -1345,6 +1349,7 @@
 				BC6FC9212961B3D800A746EE /* vImage_CGImageFormat+Extension.swift */,
 				BC83A4722403D83B006BDE06 /* VTCompressionSession+Extension.swift */,
 				BC4914AD28DDF445009E2DF6 /* VTDecompressionSession+Extension.swift */,
+				1A2166D3A449D813866FE9D9 /* AVAudioFormat+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2037,6 +2042,7 @@
 				29B8767A1CD70ACE00FC07DA /* M3U.swift in Sources */,
 				29B876901CD70AFE00FC07DA /* IOAudioUnit.swift in Sources */,
 				29B876771CD70ACE00FC07DA /* HTTPResponse.swift in Sources */,
+				1A216F07B0BD8E05C8ECC8F1 /* AVAudioFormat+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2205,6 +2211,7 @@
 				BC4914AF28DDF445009E2DF6 /* VTDecompressionSession+Extension.swift in Sources */,
 				2901A4EF1D437662002BBD23 /* MediaLink.swift in Sources */,
 				BC7C56BC299E595000C41A9B /* VideoCodecSettings.swift in Sources */,
+				1A21630C73D792376BBCFC7D /* AVAudioFormat+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2361,6 +2368,7 @@
 				29EB3DF61ED0577C001CAE8B /* CMSampleBuffer+Extension.swift in Sources */,
 				29EB3E281ED05A0C001CAE8B /* RTMPTSocket.swift in Sources */,
 				BC11024C2925147300D48035 /* IOCaptureUnit.swift in Sources */,
+				1A216A40B7F375BC52D193CC /* AVAudioFormat+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Codec/AudioCodecSettings.swift
+++ b/Sources/Codec/AudioCodecSettings.swift
@@ -3,9 +3,12 @@ import Foundation
 
 /// The AudioCodecSettings class  specifying audio compression settings.
 public struct AudioCodecSettings: Codable {
-    /// The defualt value.
+    /// The default value.
     public static let `default` = AudioCodecSettings()
-
+    
+    /// Maximum number of channels supported by the system
+    public static let maximumNumberOfChannels: UInt32 = 2
+    
     /// The type of the AudioCodec supports format.
     public enum Format: Codable {
         /// The AAC format.
@@ -98,7 +101,7 @@ public struct AudioCodecSettings: Codable {
                     mBytesPerPacket: bytesPerPacket,
                     mFramesPerPacket: framesPerPacket,
                     mBytesPerFrame: bytesPerFrame,
-                    mChannelsPerFrame: inSourceFormat.mChannelsPerFrame,
+                    mChannelsPerFrame: min(inSourceFormat.mChannelsPerFrame, AudioCodecSettings.maximumNumberOfChannels),
                     mBitsPerChannel: bitsPerChannel,
                     mReserved: 0
                 )
@@ -107,7 +110,7 @@ public struct AudioCodecSettings: Codable {
                 return AVAudioFormat(
                     commonFormat: .pcmFormatFloat32,
                     sampleRate: inSourceFormat.mSampleRate,
-                    channels: inSourceFormat.mChannelsPerFrame,
+                    channels: min(inSourceFormat.mChannelsPerFrame, AudioCodecSettings.maximumNumberOfChannels),
                     interleaved: true
                 )
             }

--- a/Sources/Extension/AVAudioFormat+Extension.swift
+++ b/Sources/Extension/AVAudioFormat+Extension.swift
@@ -1,0 +1,122 @@
+//
+// Created by Lev Sokolov on 2023-08-24.
+// Copyright (c) 2023 Shogo Endo. All rights reserved.
+//
+
+import AVFoundation
+
+extension AVAudioFormat {
+    public override var description: String {
+        var descriptionParts: [String] = []
+        
+        descriptionParts.append("Sample Rate: \(sampleRate) Hz")
+        descriptionParts.append("Channels: \(channelCount)")
+        
+        if let channelLayout = channelLayout {
+            descriptionParts.append("Channel Layout: \(channelLayout.layout.readableDescription)")
+        }
+        
+        descriptionParts.append("Format: \(commonFormat.readableDescription)")
+        descriptionParts.append(isInterleaved ? "Interleaved" : "Non-interleaved")
+        descriptionParts.append(isStandard ? "Standard" : "Non-standard")
+        
+        if let audioFormatID = audioFormatID {
+            descriptionParts.append("AudioFormatID: \(audioFormatID.audioFormatIDDescription) (\(audioFormatID))")
+        }
+        
+        descriptionParts.append("Settings: \(settings)")
+        
+        return descriptionParts.joined(separator: ", ")
+    }
+    
+    var audioFormatID: AudioFormatID? {
+        guard let formatIDValue = settings[AVFormatIDKey] as? NSNumber else {
+            return nil
+        }
+        return AudioFormatID(formatIDValue.uint32Value)
+    }
+}
+
+
+extension UnsafePointer<AudioChannelLayout> {
+    var readableDescription: String {
+        let layout = pointee
+        let channelTag = layout.mChannelLayoutTag
+        let bitmap = layout.mChannelBitmap
+        let numberChannelDescriptions = layout.mNumberChannelDescriptions
+        let channelDescriptions = channelDescriptions
+        let channelLabels = channelDescriptions.map { $0.mChannelLabel }
+        return "tag: \(channelTag), bitmap: \(bitmap), channels: \(numberChannelDescriptions), channelLabels: \(channelLabels)"
+    }
+    
+    var channelDescriptions: [AudioChannelDescription] {
+        var mutablePointee = UnsafeMutablePointer(mutating: self).pointee
+        let numberOfDescriptions = Int(mutablePointee.mNumberChannelDescriptions)
+        return withUnsafePointer(to: &mutablePointee.mChannelDescriptions) { start in
+            let descriptionsPointer = UnsafeBufferPointer<AudioChannelDescription>(start: start, count: numberOfDescriptions)
+            return (0..<numberOfDescriptions).map {
+                descriptionsPointer[$0]
+            }
+        }
+    }
+}
+
+extension AVAudioCommonFormat {
+    public var readableDescription: String {
+        switch self {
+        case .pcmFormatFloat32: return "float32"
+        case .pcmFormatFloat64: return "float64"
+        case .pcmFormatInt16: return "int16"
+        case .pcmFormatInt32: return "int32"
+        case .otherFormat: return "other"
+        @unknown default: return "unknown"
+        }
+    }
+}
+
+extension AudioFormatID {
+    public var audioFormatIDDescription: String {
+        switch self {
+        case kAudioFormatAC3: return "kAudioFormatAC3"
+        case kAudioFormatAES3: return "kAudioFormatAES3"
+        case kAudioFormatALaw: return "kAudioFormatALaw"
+        case kAudioFormatAMR: return "kAudioFormatAMR"
+        case kAudioFormatAMR_WB: return "kAudioFormatAMR_WB"
+        case kAudioFormatAppleIMA4: return "kAudioFormatAppleIMA4"
+        case kAudioFormatAppleLossless: return "kAudioFormatAppleLossless"
+        case kAudioFormatAudible: return "kAudioFormatAudible"
+        case kAudioFormatDVIIntelIMA: return "kAudioFormatDVIIntelIMA"
+        case kAudioFormatEnhancedAC3: return "kAudioFormatEnhancedAC3"
+        case kAudioFormatFLAC: return "kAudioFormatFLAC"
+        case kAudioFormatLinearPCM: return "kAudioFormatLinearPCM"
+        case kAudioFormatMACE3: return "kAudioFormatMACE3"
+        case kAudioFormatMACE6: return "kAudioFormatMACE6"
+        case kAudioFormatMIDIStream: return "kAudioFormatMIDIStream"
+        case kAudioFormatMPEG4AAC: return "kAudioFormatMPEG4AAC"
+        case kAudioFormatMPEG4AAC_ELD: return "kAudioFormatMPEG4AAC_ELD"
+        case kAudioFormatMPEG4AAC_ELD_SBR: return "kAudioFormatMPEG4AAC_ELD_SBR"
+        case kAudioFormatMPEG4AAC_ELD_V2: return "kAudioFormatMPEG4AAC_ELD_V2"
+        case kAudioFormatMPEG4AAC_HE: return "kAudioFormatMPEG4AAC_HE"
+        case kAudioFormatMPEG4AAC_HE_V2: return "kAudioFormatMPEG4AAC_HE_V2"
+        case kAudioFormatMPEG4AAC_LD: return "kAudioFormatMPEG4AAC_LD"
+        case kAudioFormatMPEG4AAC_Spatial: return "kAudioFormatMPEG4AAC_Spatial"
+        case kAudioFormatMPEG4CELP: return "kAudioFormatMPEG4CELP"
+        case kAudioFormatMPEG4HVXC: return "kAudioFormatMPEG4HVXC"
+        case kAudioFormatMPEG4TwinVQ: return "kAudioFormatMPEG4TwinVQ"
+        case kAudioFormatMPEGD_USAC: return "kAudioFormatMPEGD_USAC"
+        case kAudioFormatMPEGLayer1: return "kAudioFormatMPEGLayer1"
+        case kAudioFormatMPEGLayer2: return "kAudioFormatMPEGLayer2"
+        case kAudioFormatMPEGLayer3: return "kAudioFormatMPEGLayer3"
+        case kAudioFormatMicrosoftGSM: return "kAudioFormatMicrosoftGSM"
+        case kAudioFormatOpus: return "kAudioFormatOpus"
+        case kAudioFormatParameterValueStream: return "kAudioFormatParameterValueStream"
+        case kAudioFormatQDesign: return "kAudioFormatQDesign"
+        case kAudioFormatQDesign2: return "kAudioFormatQDesign2"
+        case kAudioFormatQUALCOMM: return "kAudioFormatQUALCOMM"
+        case kAudioFormatTimeCode: return "kAudioFormatTimeCode"
+        case kAudioFormatULaw: return "kAudioFormatULaw"
+        case kAudioFormatiLBC: return "kAudioFormatiLBC"
+        default: return "unknown"
+        }
+    }
+}


### PR DESCRIPTION
## PR
* Feature: add multi channel audio support

## Description & motivation

This change is providing an audio layout for the `AVAudioFormat` when number for channels of the input format is more than two. `AVAudioFormat` [recommends](https://developer.apple.com/documentation/avfaudio/avaudioformat/1390106-init) using `init(streamDescription:channelLayout:)`:

>If the AudioStreamBasicDescription specifies more than two channels, this method fails and returns nil. 
>Instead, use the init(streamDescription:channelLayout:)

This PR adds a method to create a layout for non mono/stereo audio formats. It also limits maximum number of output audio channels to two in `AudioCodecSettings`. Lastly, it adds a method that creates a channel mapping and provides it to the audio converter.

I tested this change with mono, stereo and 4 channel audio. Mono and stereo fall back to the previous behavior. It's possible to use channel layout as well. However, I decided to fall back to the previous implementation instead this one: 
```swift
static func makeChannelLayout(_ numberOfChannels: UInt32) -> AVAudioChannelLayout? {
    switch numberOfChannels {
    case 0: return nil
    case 1: return AVAudioChannelLayout(layoutTag: kAudioChannelLayoutTag_Mono)
    case 2: return AVAudioChannelLayout(layoutTag: kAudioChannelLayoutTag_Stereo)
    default: return AVAudioChannelLayout(layoutTag: kAudioChannelLayoutTag_DiscreteInOrder | numberOfChannels)
    }
}
```

What didn't work at all is to use custom channel descriptions:

<details>
  <summary>Code</summary>
  
```swift
static func makeChannelLayout(_ numberOfChannels: UInt32) -> AVAudioChannelLayout? {
    let channelDescriptionsPtr = UnsafeMutablePointer<AudioChannelDescription>.allocate(capacity: Int(numberOfChannels))
    
    // code for numberOfChannels >= 4
    for index in 0 ..< numberOfChannels {
        channelDescriptionsPtr[Int(index)] = AudioChannelDescription(
                mChannelLabel: AudioChannelLabel(index),
                mChannelFlags: [],
                mCoordinates: (0, 0, 0)
        )
    }
    
    var channelLayout = AudioChannelLayout(
            mChannelLayoutTag: kAudioChannelLayoutTag_UseChannelDescriptions,
            mChannelBitmap: [],
            mNumberChannelDescriptions: numberOfChannels,
            mChannelDescriptions: channelDescriptionsPtr.pointee
    )
    
    return AVAudioChannelLayout(layout: &channelLayout)
}
```
  
</details>

Every call of `AVAudioChannelLayout(layout: &channelLayout)` generates `AVAudioChannelLayout` instance with random number of channels. I wasn't able to find any combination of `mChannelLabel` to create a stable result. Ring buffer and converter end up having different audio formats which leads to a crash: `required condition is false: [impl->_inputBufferReceived.format isEqual: impl->_inputFormat]`.

<details>
  <summary>Examples of random channel layouts</summary>
  
  All instances of `AVAudioChannelLayout` was provided with the same `AudioChannelLayout`. `AVAudioChannelLayout` attempts to make a conversion as states in the doc. Somehow it creates random layout every time:
Example 1:
>"tag: Unknown, bitmap: AudioChannelBitmap(rawValue: 36915), channels: 51, channelLabels: ["Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Left 1", "Unknown 4294967295", "Unknown 582390464", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Left 1", "Unknown 2147783024", ..."

Example 2:
>"tag: Unknown, bitmap: AudioChannelBitmap(rawValue: 36915), channels: 143, channelLabels: ["Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unknown 1400468065", "Unknown 1936942419", "Unknown 1649632357", "Unknown 1600279396", "Unknown 582482080", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unknown 36915", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "LeftSurroundDirect 10", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unknown 1852795252", "Unknown 1633971829", "Unknown 1953391972", "Unknown 1918985326", "Unused 0", "Unknown 1098085743", "Unknown 1835099506", "Unknown 1769234787", "Unknown 1600939364", "Unknown 3935328888", "Right 2", "Unused 0", "Unused 0", "Unused 0", ..."

Example 3:
>"tag: Unknown, bitmap: AudioChannelBitmap(rawValue: 36915), channels: 36, channelLabels: ["Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unused 0", "Unknown 3935305977", "Unknown 792359792", "Unknown 1734633847", "Unknown 1969434488", "Unknown 112", "Unknown 4294967295", "Unknown 4294967295", "Unused 0", "Unused 0", "Unused 0", "Right 2", "Right 2", "Right 2", "Unused 0", "Unused 0", "Unused 0", "Unknown 2147849040", "Unused 0", "Unused 0", "Unused 0", "Unknown 106152448", "Unused 0", "Unused 0", "Unknown 4294967295", "Unknown 4294967295", "Unused 0", "Unused 0"]"
  
</details>

More discussion in this issue: #1262 

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

