### PR TITLE
Improve audio channel mapping

### DIFF
--- a/Sources/Codec/AudioCodec.swift
+++ b/Sources/Codec/AudioCodec.swift
@@ -50,18 +50,13 @@ public class AudioCodec {
 
     /// Creates a channel map for specific input and output format
     static func makeChannelMap(inChannels: Int, outChannels: Int, outputChannelsMap: [Int: Int]) -> [NSNumber] {
-        var result = (0..<outChannels).map { $0 }
+        var result = Array(repeating: -1, count: outChannels)
+        for inputIndex in 0..<min(inChannels, outChannels) {
+            result[inputIndex] = inputIndex
+        }
         for currentIndex in 0..<outChannels {
-            if let inputIndex = outputChannelsMap[currentIndex] {
-                if inputIndex < inChannels {
-                    result[currentIndex] = inputIndex < inChannels ? inputIndex : currentIndex
-                }
-                else {
-                    result[currentIndex] = currentIndex
-                }
-            }
-            else if currentIndex >= inChannels {
-                result[currentIndex] = -1
+            if let inputIndex = outputChannelsMap[currentIndex], inputIndex < inChannels {
+                result[currentIndex] = inputIndex
             }
         }
         return result.map { NSNumber(value: $0) }

--- a/Sources/Codec/AudioCodec.swift
+++ b/Sources/Codec/AudioCodec.swift
@@ -49,17 +49,22 @@ public class AudioCodec {
     }
 
     /// Creates a channel map for specific input and output format
-    /// - Examples:
-    ///   - Input channel count is 4 and 2, result:  [0, 1, -1, -1]
-    ///   - Input channel count is 2 and 2, result:  [0, 1]
-    static func makeChannelMap(from fromFormat: AVAudioFormat, to toFormat: AVAudioFormat) -> [NSNumber] {
-        let inChannels = Int(fromFormat.channelCount)
-        let outChannels = Int(toFormat.channelCount)
-        let channelIndexes = Array(0...inChannels - 1)
-        return channelIndexes
-            .prefix(outChannels)
-            .map { NSNumber(value: $0) }
-            + Array(repeating: -1, count: max(0, inChannels - outChannels))
+    static func makeChannelMap(inChannels: Int, outChannels: Int, outputChannelsMap: [Int: Int]) -> [NSNumber] {
+        var result = (0..<outChannels).map { $0 }
+        for currentIndex in 0..<outChannels {
+            if let inputIndex = outputChannelsMap[currentIndex] {
+                if inputIndex < inChannels {
+                    result[currentIndex] = inputIndex < inChannels ? inputIndex : currentIndex
+                }
+                else {
+                    result[currentIndex] = currentIndex
+                }
+            }
+            else if currentIndex >= inChannels {
+                result[currentIndex] = -1
+            }
+        }
+        return result.map { NSNumber(value: $0) }
     }
 
     /// Specifies the delegate.
@@ -194,7 +199,10 @@ public class AudioCodec {
         logger.debug("inputFormat: \(inputFormat)")
         logger.debug("outputFormat: \(outputFormat)")
         let converter = AVAudioConverter(from: inputFormat, to: outputFormat)
-        converter?.channelMap = Self.makeChannelMap(from: inputFormat, to: outputFormat)
+        let channelMap = Self.makeChannelMap(inChannels: Int(inputFormat.channelCount), outChannels: Int(outputFormat.channelCount),
+                outputChannelsMap: settings.outputChannelsMap)
+        logger.debug("channelMap: \(channelMap)")
+        converter?.channelMap = channelMap
         settings.apply(converter, oldValue: nil)
         if converter == nil {
             delegate?.audioCodec(self, errorOccurred: .failedToCreate(from: inputFormat, to: outputFormat))

--- a/Sources/Codec/AudioCodecSettings.swift
+++ b/Sources/Codec/AudioCodecSettings.swift
@@ -122,14 +122,23 @@ public struct AudioCodecSettings: Codable {
 
     /// Specifies the output format.
     public var format: AudioCodecSettings.Format
+    
+    /// Map of the output to input channels
+    public var outputChannelsMap: [Int: Int]
 
     /// Create an new AudioCodecSettings instance.
     public init(
         bitRate: Int = 64 * 1000,
-        format: AudioCodecSettings.Format = .aac
+        format: AudioCodecSettings.Format = .aac,
+        outputChannelsMap: [Int: Int] = [0: 0, 1: 1]
     ) {
         self.bitRate = bitRate
         self.format = format
+        self.outputChannelsMap = outputChannelsMap
+    }
+    
+    func recreateConverter(_ rhs: AudioCodecSettings) -> Bool {
+        !(outputChannelsMap == rhs.outputChannelsMap)
     }
 
     func apply(_ converter: AVAudioConverter?, oldValue: AudioCodecSettings?) {

--- a/Tests/Codec/AudioCodecTests.swift
+++ b/Tests/Codec/AudioCodecTests.swift
@@ -93,5 +93,36 @@ final class AudioCodecTests: XCTestCase {
             encoder.appendSampleBuffer(sampleBuffer)
         }
     }
+
+    func testChannelMaps() {
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 1, outputChannelsMap: [:]), [0])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 1, outputChannelsMap: [0: 0]), [0])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 1, outputChannelsMap: [0: 0, 1: 1]), [0])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 1, outputChannelsMap: [0: -1]), [-1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 1, outputChannelsMap: [Int.max: Int.max]), [0])
+
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 2, outputChannelsMap: [:]), [0, -1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 2, outputChannelsMap: [0: 0]), [0, -1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 2, outputChannelsMap: [0: 1]), [0, -1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 2, outputChannelsMap: [0: -1, 1: -1]), [-1, -1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 2, outputChannelsMap: [0: 1, 1: Int.max]), [0, 1])
+
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 1, outputChannelsMap: [:]), [0])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 1, outputChannelsMap: [0: 0]), [0])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 1, outputChannelsMap: [0: 1]), [1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 1, outChannels: 1, outputChannelsMap: [0: -1]), [-1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 1, outputChannelsMap: [Int.max: 0]), [0])
+
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 2, outputChannelsMap: [:]), [0, 1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 2, outputChannelsMap: [0: 0]), [0, 1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 2, outputChannelsMap: [0: 0, 1: 1]), [0, 1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 2, outputChannelsMap: [0: -1, 1: -1]), [-1, -1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 2, outputChannelsMap: [0: -1, 1: 1]), [-1, 1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 2, outputChannelsMap: [0: 0, 1: 1, Int.max: Int.max]), [0, 1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 2, outChannels: 2, outputChannelsMap: [0: 0, 1: Int.max]), [0, 1])
+
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 12, outChannels: 2, outputChannelsMap: [:]), [0, 1])
+        XCTAssertEqual(AudioCodec.makeChannelMap(inChannels: 12, outChannels: 2, outputChannelsMap: [0: -1, 1: 11]), [-1, 11])
+    }
 }
 


### PR DESCRIPTION
## Description & motivation

* Fix audio channel mapping. My previous implementation was creating a channel map of size n, where n is number of input channels. It should use number of output output channels instead.
* Expose channel map for external use
* Add channel map unit tests

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

