### PR TITLE
Creating RTMP onMetaData based on input data.

### DIFF
--- a/Sources/Codec/AudioCodec.swift
+++ b/Sources/Codec/AudioCodec.swift
@@ -53,6 +53,9 @@ public class AudioCodec {
             }
         }
     }
+    var outputFormat: AVAudioFormat? {
+        return audioConverter?.outputFormat
+    }
     private var cursor: Int = 0
     private var inputBuffers: [AVAudioBuffer] = []
     private var outputBuffers: [AVAudioBuffer] = []

--- a/Sources/Codec/VTSessionMode.swift
+++ b/Sources/Codec/VTSessionMode.swift
@@ -37,7 +37,7 @@ enum VTSessionMode {
             }
             return session
         case .decompression:
-            guard let formatDescription = videoCodec.formatDescription else {
+            guard let formatDescription = videoCodec.outputFormat else {
                 videoCodec.delegate?.videoCodec(videoCodec, errorOccurred: .failedToCreate(status: kVTParameterErr))
                 return nil
             }

--- a/Sources/Codec/VideoCodec.swift
+++ b/Sources/Codec/VideoCodec.swift
@@ -62,12 +62,12 @@ public class VideoCodec {
 
     var lockQueue = DispatchQueue(label: "com.haishinkit.HaishinKit.VideoCodec.lock")
     var expectedFrameRate = IOMixer.defaultFrameRate
-    var formatDescription: CMFormatDescription? {
+    private(set) var outputFormat: CMFormatDescription? {
         didSet {
-            guard !CMFormatDescriptionEqual(formatDescription, otherFormatDescription: oldValue) else {
+            guard !CMFormatDescriptionEqual(outputFormat, otherFormatDescription: oldValue) else {
                 return
             }
-            delegate?.videoCodec(self, didOutput: formatDescription)
+            delegate?.videoCodec(self, didOutput: outputFormat)
         }
     }
     var needsSync: Atomic<Bool> = .init(true)
@@ -108,7 +108,7 @@ public class VideoCodec {
                 delegate?.videoCodec(self, errorOccurred: .failedToFlame(status: status))
                 return
             }
-            formatDescription = sampleBuffer.formatDescription
+            outputFormat = sampleBuffer.formatDescription
             delegate?.videoCodec(self, didOutput: sampleBuffer)
         }
     }
@@ -214,7 +214,7 @@ extension VideoCodec: Running {
             self.session = nil
             self.invalidateSession = true
             self.needsSync.mutate { $0 = true }
-            self.formatDescription = nil
+            self.outputFormat = nil
             #if os(iOS)
             NotificationCenter.default.removeObserver(self, name: AVAudioSession.interruptionNotification, object: nil)
             NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)

--- a/Sources/Media/HKView.swift
+++ b/Sources/Media/HKView.swift
@@ -28,11 +28,6 @@ public class HKView: UIView {
         }
     }
 
-    /// A value that displays a video format.
-    public var videoFormatDescription: CMVideoFormatDescription? {
-        currentStream?.mixer.videoIO.formatDescription
-    }
-
     #if !os(tvOS)
     public var videoOrientation: AVCaptureVideoOrientation = .portrait {
         didSet {
@@ -137,11 +132,6 @@ public class HKView: NSView {
         didSet {
             layer?.setValue(videoGravity.rawValue, forKey: "videoGravity")
         }
-    }
-
-    /// A value that displays a video format.
-    public var videoFormatDescription: CMVideoFormatDescription? {
-        currentStream?.mixer.videoIO.formatDescription
     }
 
     public var videoOrientation: AVCaptureVideoOrientation = .portrait

--- a/Sources/Media/IOAudioResampler.swift
+++ b/Sources/Media/IOAudioResampler.swift
@@ -76,6 +76,10 @@ final class IOAudioResampler<T: IOAudioResamplerDelegate> {
     }
     weak var delegate: T?
 
+    var inputFormat: AVAudioFormat? {
+        return audioConverter?.inputFormat
+    }
+
     var outputFormat: AVAudioFormat? {
         return audioConverter?.outputFormat
     }

--- a/Sources/Media/IOMixer.swift
+++ b/Sources/Media/IOMixer.swift
@@ -222,7 +222,6 @@ public final class IOMixer {
             case kCMMediaType_Audio:
                 audioIO.codec.appendSampleBuffer(sampleBuffer)
             case kCMMediaType_Video:
-                videoIO.codec.formatDescription = sampleBuffer.formatDescription
                 videoIO.codec.appendSampleBuffer(sampleBuffer)
             default:
                 break

--- a/Sources/Media/IOUnit.swift
+++ b/Sources/Media/IOUnit.swift
@@ -5,8 +5,12 @@ import Foundation
 public typealias AVCodecDelegate = AudioCodecDelegate & VideoCodecDelegate
 
 protocol IOUnit {
+    associatedtype FormatDescription
+
     var mixer: IOMixer? { get set }
     var muted: Bool { get set }
+    var inputFormat: FormatDescription? { get }
+    var outputFormat: FormatDescription? { get }
 
     func appendSampleBuffer(_ sampleBuffer: CMSampleBuffer)
 }

--- a/Sources/Media/MTHKView.swift
+++ b/Sources/Media/MTHKView.swift
@@ -9,10 +9,6 @@ public class MTHKView: MTKView {
     /// Specifies how the video is displayed within a player layer’s bounds.
     public var videoGravity: AVLayerVideoGravity = .resizeAspect
 
-    public var videoFormatDescription: CMVideoFormatDescription? {
-        currentStream?.mixer.videoIO.formatDescription
-    }
-
     #if !os(tvOS)
     public var videoOrientation: AVCaptureVideoOrientation = .portrait
     #endif

--- a/Sources/Media/PiPHKView.swift
+++ b/Sources/Media/PiPHKView.swift
@@ -25,11 +25,6 @@ public class PiPHKView: UIView {
         }
     }
 
-    /// A value that displays a video format.
-    public var videoFormatDescription: CMVideoFormatDescription? {
-        currentStream?.mixer.videoIO.formatDescription
-    }
-
     #if !os(tvOS)
     public var videoOrientation: AVCaptureVideoOrientation = .portrait {
         didSet {
@@ -117,11 +112,6 @@ public class PiPHKView: NSView {
         didSet {
             layer?.setValue(videoGravity, forKey: "videoGravity")
         }
-    }
-
-    /// A value that displays a video format.
-    public var videoFormatDescription: CMVideoFormatDescription? {
-        currentStream?.mixer.videoIO.formatDescription
     }
 
     public var videoOrientation: AVCaptureVideoOrientation = .portrait {

--- a/Sources/Net/NetStreamDrawable.swift
+++ b/Sources/Net/NetStreamDrawable.swift
@@ -8,9 +8,6 @@ public protocol NetStreamDrawable: AnyObject {
     var videoOrientation: AVCaptureVideoOrientation { get set }
     #endif
 
-    /// The videoFormatDescription which is the current CMSampleBuffer.
-    var videoFormatDescription: CMVideoFormatDescription? { get }
-
     /// Attaches a drawable to a new NetStream object.
     func attachStream(_ stream: NetStream?)
 

--- a/Sources/RTMP/RTMPMessage.swift
+++ b/Sources/RTMP/RTMPMessage.swift
@@ -709,7 +709,7 @@ final class RTMPVideoMessage: RTMPMessage {
                 dataReady: true,
                 makeDataReadyCallback: nil,
                 refcon: nil,
-                formatDescription: stream.mixer.videoIO.formatDescription,
+                formatDescription: stream.mixer.videoIO.inputFormat,
                 sampleCount: 1,
                 sampleTimingEntryCount: 1,
                 sampleTimingArray: &timing,
@@ -728,11 +728,11 @@ final class RTMPVideoMessage: RTMPMessage {
         case .h264:
             var config = AVCDecoderConfigurationRecord()
             config.data = payload.subdata(in: FLVTagType.video.headerSize..<payload.count)
-            status = config.makeFormatDescription(&stream.mixer.videoIO.formatDescription)
+            status = config.makeFormatDescription(&stream.mixer.videoIO.inputFormat)
         case .hevc:
             var config = HEVCDecoderConfigurationRecord()
             config.data = payload.subdata(in: FLVTagType.video.headerSize..<payload.count)
-            status = config.makeFormatDescription(&stream.mixer.videoIO.formatDescription)
+            status = config.makeFormatDescription(&stream.mixer.videoIO.inputFormat)
         }
         if status == noErr {
             stream.mixer.mediaLink.hasVideo = true

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -413,24 +413,24 @@ open class RTMPStream: NetStream {
     /// Creates flv metadata for a stream.
     open func makeMetaData() -> ASObject {
         var metadata: [String: Any] = [:]
-        #if os(iOS) || os(macOS)
-        if mixer.videoIO.capture.device != nil {
-            metadata["width"] = mixer.videoIO.codec.settings.videoSize.width
-            metadata["height"] = mixer.videoIO.codec.settings.videoSize.height
-            metadata["framerate"] = mixer.videoIO.frameRate
-            switch mixer.videoIO.codec.settings.format {
+        if mixer.videoIO.inputFormat != nil {
+            metadata["width"] = videoSettings.videoSize.width
+            metadata["height"] = videoSettings.videoSize.height
+            metadata["framerate"] = frameRate
+            switch videoSettings.format {
             case .h264:
                 metadata["videocodecid"] = FLVVideoCodec.avc.rawValue
             case .hevc:
                 metadata["videocodecid"] = FLVVideoFourCC.hevc.rawValue
             }
-            metadata["videodatarate"] = mixer.videoIO.codec.settings.bitRate / 1000
+            metadata["videodatarate"] = videoSettings.bitRate / 1000
         }
-        #endif
-        if let inSourceFormat = mixer.audioIO.codec.inSourceFormat {
+        if mixer.audioIO.inputFormat != nil {
             metadata["audiocodecid"] = FLVAudioCodec.aac.rawValue
             metadata["audiodatarate"] = audioSettings.bitRate / 1000
-            metadata["audiosamplerate"] = inSourceFormat.mSampleRate
+            if let outputFormat = mixer.audioIO.outputFormat?.audioStreamBasicDescription {
+                metadata["audiosamplerate"] = outputFormat.mSampleRate
+            }
         }
         return metadata
     }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- The creation condition for onMetaData was originally based on the presence of a device attachment, but it has been switched to the presence of a signal. This change allows sending metadata as expected without the need to inherit RTMPStream, even with APIs like ReplayKit or ScreenCaptureKit.
- https://github.com/shogo4405/HaishinKit.swift/pull/1074

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

