### PR TITLE
Configuration for IOVideoCaptureUnit.

### DIFF
--- a/Examples/macOS/CameraIngestViewController.swift
+++ b/Examples/macOS/CameraIngestViewController.swift
@@ -35,11 +35,11 @@ final class CameraIngestViewController: NSViewController {
     override func viewDidAppear() {
         super.viewDidAppear()
         stream.attachAudio(DeviceUtil.device(withLocalizedName: audioPopUpButton.titleOfSelectedItem!, mediaType: .audio))
-        stream.attachCamera(DeviceUtil.device(withLocalizedName: cameraPopUpButton.titleOfSelectedItem!, mediaType: .video))
+        stream.attachCamera(DeviceUtil.device(withLocalizedName: cameraPopUpButton.titleOfSelectedItem!, mediaType: .video), channel: 0)
         var devices = AVCaptureDevice.devices(for: .video)
         devices.removeFirst()
         if let device = devices.first {
-            stream.attachMultiCamera(device)
+            stream.attachCamera(device, channel: 1)
         }
     }
 
@@ -71,6 +71,6 @@ final class CameraIngestViewController: NSViewController {
 
     @IBAction private func selectCamera(_ sender: AnyObject) {
         let device = DeviceUtil.device(withLocalizedName: cameraPopUpButton.titleOfSelectedItem!, mediaType: .video)
-        stream.attachCamera(device)
+        stream.attachCamera(device, channel: 0)
     }
 }

--- a/Sources/Codec/VideoCodecSettings.swift
+++ b/Sources/Codec/VideoCodecSettings.swift
@@ -121,7 +121,7 @@ public struct VideoCodecSettings: Codable {
         scalingMode: ScalingMode = .trim,
         bitRateMode: BitRateMode = .average,
         maxKeyFrameIntervalDuration: Int32 = 2,
-        allowFrameReordering: Bool? = nil, // swiftlint:disable:this discouraged_optional_boolean,
+        allowFrameReordering: Bool? = nil, // swiftlint:disable:this discouraged_optional_boolean
         dataRateLimits: [Double]? = [0.0, 0.0],
         isHardwareEncoderEnabled: Bool = true
     ) {

--- a/Sources/IO/IOAudioUnit.swift
+++ b/Sources/IO/IOAudioUnit.swift
@@ -4,11 +4,11 @@ import AVFoundation
 import SwiftPMSupport
 #endif
 
-/// The IO audio unit  error domain codes.
+/// The IOAudioUnit  error domain codes.
 public enum IOAudioUnitError: Swift.Error {
-    /// The IO audio unit  failed to create the AVAudioConverter..
+    /// The IOAudioUnit  failed to create the AVAudioConverter.
     case failedToCreate(from: AVAudioFormat?, to: AVAudioFormat?)
-    /// The IO audio unit  faild to convert the an audio buffer.
+    /// The IOAudioUnit  faild to convert the an audio buffer.
     case failedToConvert(error: NSError)
 }
 

--- a/Sources/IO/IOVideoCaptureUnit.swift
+++ b/Sources/IO/IOVideoCaptureUnit.swift
@@ -2,6 +2,9 @@
 import AVFoundation
 import Foundation
 
+/// Configuration calback block for IOVideoUnit.
+public typealias IOVideoCaptureConfigurationBlock = (IOVideoCaptureUnit?, IOVideoUnitError?) -> Void
+
 /// An object that provides the interface to control the AVCaptureDevice's transport behavior.
 @available(tvOS 17.0, *)
 public final class IOVideoCaptureUnit: IOCaptureUnit {


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->
I modified the method to make it easier to perform the initial setup of IOVideoCaptureUnit when using attachCamera. You can handle it with a callback as follows.
```swift
stream.attachCamera(back, channel: 0) { videoCaptureUnit, error in
    videoCaptureUnit?.isVideoMirrored = false
    videoCaptureUnit?.preferredVideoStabilizationMode = .standard
    videoCaptureUnit?.colorFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
  if let error {
    logger.warn(error)
  }
}
```

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

