### PR TITLE
Feature: Make `defaultTimeout` property a variable instead of a constant.

### DIFF
--- a/Sources/Net/NetSocket.swift
+++ b/Sources/Net/NetSocket.swift
@@ -3,7 +3,7 @@ import Foundation
 /// The NetSocket class creates a two-way connection between a client and a server as a client. This class is wrapper for a InputStream and an OutputStream.
 open class NetSocket: NSObject {
     /// The default time to wait for TCP/IP Handshake done.
-    public static let defaultTimeout: Int = 15 // sec
+    public static var defaultTimeout: Int = 15 // sec
     /// The defulat stream's TCP window size.
     public static let defaultWindowSizeC = Int(UInt16.max)
     /// The current incoming data buffer.


### PR DESCRIPTION
## Description & motivation

In a project I'm currently working on, we've found it handy to be able to override the defaultTimeout property which is currently defined as a constant. 

Currently we are forking the library and have made this modification there, however it's the last remaining change that we need the fork for. So, I am proposing to update the main library and we can do away with maintaining a custom fork. 

I'm not suggesting it's advisable to change the value of this property necessarily, and I respect that if you'd rather leave it as a constant, but it works for a specific need we have and I thought I'd propose making the change in the main library as well since it's purely an additive change that allows users of the library additional flexibility without breaking any existing code.  

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality [to the library])

