### PR TITLE
Fix crash set RTMPConneciton.timeout.

### DIFF
--- a/Sources/Net/NetSocket.swift
+++ b/Sources/Net/NetSocket.swift
@@ -4,8 +4,11 @@ import Foundation
 open class NetSocket: NSObject {
     /// The default time to wait for TCP/IP Handshake done.
     public static let defaultTimeout: Int = 15 // sec
-    /// The defulat stream's TCP window size.
+    /// The default stream's TCP window size.
     public static let defaultWindowSizeC = Int(UInt16.max)
+    /// The default quality of service.
+    public static let defaultQualityOfService: DispatchQoS = .userInitiated
+
     /// The current incoming data buffer.
     public var inputBuffer = Data()
     /// Specifies time to wait for TCP/IP Handshake done.
@@ -17,7 +20,7 @@ open class NetSocket: NSObject {
     /// Specifies  statistics of total incoming bytes.
     public var totalBytesIn: Atomic<Int64> = .init(0)
     /// Specifies  instance's quality of service for a Socket IO.
-    public var qualityOfService: DispatchQoS = .userInitiated
+    public var qualityOfService: DispatchQoS = NetSocket.defaultQualityOfService
     /// Specifies instance determine to use the secure-socket layer (SSL) security level.
     public var securityLevel: StreamSocketSecurityLevel = .none
     /// Specifies the output buffer size in bytes.

--- a/Sources/RTMP/RTMPMessage.swift
+++ b/Sources/RTMP/RTMPMessage.swift
@@ -109,7 +109,7 @@ final class RTMPSetChunkSizeMessage: RTMPMessage {
     }
 
     override func execute(_ connection: RTMPConnection, type: RTMPChunkType) {
-        connection.socket.chunkSizeC = Int(size)
+        connection.socket?.chunkSizeC = Int(size)
     }
 }
 
@@ -729,7 +729,7 @@ final class RTMPUserControlMessage: RTMPMessage {
     override func execute(_ connection: RTMPConnection, type: RTMPChunkType) {
         switch event {
         case .ping:
-            connection.socket.doOutput(chunk: RTMPChunk(
+            connection.socket?.doOutput(chunk: RTMPChunk(
                 type: .zero,
                 streamId: RTMPChunk.StreamID.control.rawValue,
                 message: RTMPUserControlMessage(event: .pong, value: value)


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
I have fixed the issue where the value of connection.timeout could not be set as expected in the instance's state.
```
let conneciton = RTMPConnection()
conneciton.timeout = 5
```

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:
<img width="1219" alt="スクリーンショット 2023-12-18 20 09 19" src="https://github.com/shogo4405/HaishinKit.swift/assets/810189/fcf28809-34ec-4787-b574-2c6b342e08f9">

