### PR TITLE
Fix: SwiftUI fixes for initial video and audio

### DIFF
--- a/Examples/iOSSwiftUI/Model/ViewModel.swift
+++ b/Examples/iOSSwiftUI/Model/ViewModel.swift
@@ -65,7 +65,7 @@ final class ViewModel: ObservableObject {
             rtmpStream.videoOrientation = orientation
         }
         rtmpStream.sessionPreset = .hd1280x720
-        rtmpStream.videoSettings.videoSize = .init(width: 720, height: 1280)
+        rtmpStream.videoSettings.videoSize = .init(width: 1280, height: 720)
         nc.publisher(for: UIDevice.orientationDidChangeNotification, object: nil)
             .sink { [weak self] _ in
                 guard let orientation = DeviceUtil.videoOrientation(by: UIDevice.current.orientation), let self = self else {

--- a/Examples/iOSSwiftUI/iOSSwiftUIApp.swift
+++ b/Examples/iOSSwiftUI/iOSSwiftUIApp.swift
@@ -23,7 +23,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // Logboard.with(HaishinKitIdentifier).level = .trace
         let session = AVAudioSession.sharedInstance()
         do {
-            try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .allowBluetooth])
+            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .allowBluetooth])
             try session.setActive(true)
         } catch {
             logger.error(error)

--- a/Sources/Codec/VideoCodecSettings.swift
+++ b/Sources/Codec/VideoCodecSettings.swift
@@ -121,7 +121,9 @@ public struct VideoCodecSettings: Codable {
         scalingMode: ScalingMode = .trim,
         bitRateMode: BitRateMode = .average,
         maxKeyFrameIntervalDuration: Int32 = 2,
-        allowFrameReordering: Bool? = nil, // swiftlint:disable:this discouraged_optional_boolean
+        // swiftlint:disable discouraged_optional_boolean
+        allowFrameReordering: Bool? = nil,
+        // swiftlint:enable discouraged_optional_boolean
         dataRateLimits: [Double]? = [0.0, 0.0],
         isHardwareEncoderEnabled: Bool = true
     ) {


### PR DESCRIPTION
## Description & motivation

Fixed a bug in the initial setting of video in SwiftUI example. Also changed the AVAudioSession mode to get audio working in SwiftUI example.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

