### PR TITLE
Change RTMPStream readyState observers to open

### DIFF
--- a/Examples/iOS/NetStreamSwitcher.swift
+++ b/Examples/iOS/NetStreamSwitcher.swift
@@ -162,4 +162,12 @@ extension NetStreamSwitcher: IOStreamDelegate {
     /// Tells the receiver to the stream opened.
     func streamDidOpen(_ stream: IOStream) {
     }
+
+    /// Tells the receiver that the ready state will change.
+    func stream(_ stream: IOStream, willChangeReadyState state: IOStream.ReadyState) {
+    }
+
+    /// Tells the receiver that the ready state did change.
+    func stream(_ stream: IOStream, didChangeReadyState state: IOStream.ReadyState) {
+    }
 }

--- a/Sources/IO/IOStream.swift
+++ b/Sources/IO/IOStream.swift
@@ -34,6 +34,10 @@ public protocol IOStreamDelegate: AnyObject {
     func stream(_ stream: IOStream, audioErrorOccurred error: IOAudioUnitError)
     /// Tells the receiver to the stream opened.
     func streamDidOpen(_ stream: IOStream)
+    /// Tells the receiver that the ready state will change.
+    func stream(_ stream: IOStream, willChangeReadyState state: IOStream.ReadyState)
+    /// Tells the receiver that the ready state did change.
+    func stream(_ stream: IOStream, didChangeReadyState state: IOStream.ReadyState)
 }
 
 @available(*, deprecated, renamed: "IOStream")
@@ -301,6 +305,7 @@ open class IOStream: NSObject {
             guard readyState != newValue else {
                 return
             }
+            delegate?.stream(self, willChangeReadyState: readyState)
             readyStateWillChange(to: newValue)
         }
         didSet {
@@ -308,6 +313,7 @@ open class IOStream: NSObject {
                 return
             }
             readyStateDidChange(to: readyState)
+            delegate?.stream(self, didChangeReadyState: readyState)
         }
     }
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

This small change makes readyState open. It helps to observe changes of `readyState` property of `IOStream`.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

