### PR TITLE
Add an option to show video output on a drawable without video effects

### DIFF
--- a/Sources/IO/IOVideoMixer.swift
+++ b/Sources/IO/IOVideoMixer.swift
@@ -107,7 +107,7 @@ final class IOVideoMixer<T: IOVideoMixerDelegate> {
                 #if os(macOS)
                 pixelBufferPool?.createPixelBuffer(&imageBuffer)
                 #else
-                if buffer.width != Int(extent.width) || buffer.height != Int(extent.height) {
+                if settings.alwaysUseBufferPoolForVideoEffects || buffer.width != Int(extent.width) || buffer.height != Int(extent.height) {
                     pixelBufferPool?.createPixelBuffer(&imageBuffer)
                 }
                 #endif

--- a/Sources/IO/IOVideoMixerSettings.swift
+++ b/Sources/IO/IOVideoMixerSettings.swift
@@ -36,6 +36,8 @@ public struct IOVideoMixerSettings: Codable {
     public let direction: ImageTransform
     /// Specifies the main channel number.
     public var channel: UInt8 = 0
+    /// Specifies if effects are always rendered to a new buffer.
+    public var alwaysUseBufferPoolForVideoEffects: Bool = false
 
     /// Create a new IOVideoMixerSettings.
     public init(mode: Mode, cornerRadius: CGFloat, regionOfInterest: CGRect, direction: ImageTransform) {


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation

This PR brings an option to display camera output on a drawable before applying the video effects. It allows to show the video effects only on the stream. Default value is the same as before. `effectsBuffer` flags helps to prevent the race condition when the video effects appear on the drawable for some frames; it happens when effects rendering is faster than drawable rendering.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

