### PR TITLE
Validate audio channel map before applying

### DIFF
--- a/Sources/IO/IOAudioResampler.swift
+++ b/Sources/IO/IOAudioResampler.swift
@@ -35,7 +35,7 @@ struct IOAudioResamplerSettings {
         if converter.downmix != downmix {
             converter.downmix = downmix
         }
-        if let channelMap {
+        if let channelMap = validatedChannelMap(converter) {
             converter.channelMap = channelMap
         } else {
             switch converter.outputFormat.channelCount {
@@ -59,6 +59,18 @@ struct IOAudioResamplerSettings {
             channels: min(channels == 0 ? inputFormat.channelCount : channels, AudioCodecSettings.maximumNumberOfChannels),
             interleaved: inputFormat.isInterleaved
         )
+    }
+    
+    private func validatedChannelMap(_ converter: AVAudioConverter) -> [NSNumber]? {
+        guard let channelMap, channelMap.count == converter.outputFormat.channelCount else {
+            return nil
+        }
+        for inputChannel in channelMap {
+            if inputChannel.intValue >= converter.inputFormat.channelCount {
+                return nil
+            }
+        }
+        return channelMap
     }
 }
 


### PR DESCRIPTION
## Description & motivation

Feature: Add audio channel map validation

Here's a case I'm trying to solve:
1. User connects an audio device with 2 input channels
2. User sets the output channel map to [0, 1]
3. User disconnects the input device, so now input has only 1 channel from the default mic
4. Audio converter crashes [here](https://github.com/shogo4405/HaishinKit.swift/blob/c712fe74d7fd555ada5b533dcdbfc939f4381caf/Sources/IO/IOAudioResampler.swift#L187) because it tries to map the second channel that isn't available anymore

There are other situations like this, for instance, just setting `stream.audioSettings.channelMap = [3]`.
The problem here is that audio input and output formats are not exposed outside of the library and `channelMap` cannot be corrected before it's applied to the converter. 

Theoretically, both formats or the converted itself could be exposed, but it has some downsides. For example, need to add extra delegate methods to IOAudioResamplerDelegate -> IOAudioUnitDelegate -> IOMixerDelegate -> IOStreamDelegate. So I choose an option to automatically validate the current channelMap to make sure that:
1. The length of the array is equal to the number of output channels
2. The array doesn't contain invalid input channels

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

