### PR TITLE
Set IOVideoUnit inputFormat when new buffer is available

### DIFF
--- a/Sources/IO/IOVideoUnit.swift
+++ b/Sources/IO/IOVideoUnit.swift
@@ -279,6 +279,7 @@ extension IOVideoUnit {
 extension IOVideoUnit: IOVideoMixerDelegate {
     // MARK: IOVideoMixerDelegate
     func videoMixer(_ videoMixer: IOVideoMixer<IOVideoUnit>, didOutput sampleBuffer: CMSampleBuffer) {
+        inputFormat = sampleBuffer.formatDescription
         drawable?.enqueue(sampleBuffer)
         mixer?.videoUnit(self, didOutput: sampleBuffer)
     }


### PR DESCRIPTION
## Description & motivation

This PR fixes an issue where `inputFormat` of `IOVideoUnit` is nil. As result, `videoInputFormat` is nil when `RTMPStream` calls `makeMetaData` during camera streaming. It was working [previously](https://github.com/shogo4405/HaishinKit.swift/commit/0baa40b#diff-009d825f8c7bbcf073d4e25661a7aef9a8a87361d66a2d4e118798be8c334b74R560) when `IOVideoUnit` was calling a local "append" method that was updating `inputFormat`. Now it only passes new buffers from `IOVideoMixerDelegate` to drawable and mixer, so this PR sets the format in the delegate method too. 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

