### PR TITLE
Add a public method to send metadata

### DIFF
--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -371,6 +371,9 @@ open class RTMPStream: IOStream {
             guard let connection = self.connection, self.readyState == .publishing(muxer: self.muxer) else {
                 return
             }
+            if handlerName == "@setDataFrame" {
+                self.dataTimeStamps.removeValue(forKey: handlerName)
+            }
             let dataWasSent = self.dataTimeStamps[handlerName] == nil ? false : true
             let timestmap: UInt32 = dataWasSent ? UInt32((self.dataTimeStamps[handlerName]?.timeIntervalSinceNow ?? 0) * -1000) : UInt32(self.startedAt.timeIntervalSinceNow * -1000)
             let chunk = RTMPChunk(


### PR DESCRIPTION
## Description & motivation

This PR adds a public method to send the stream metadata manually. This allow to reset metadata timestamp and send metadata to the server when resolution/orientation of the stream has changed. It works on major platforms like YouTube and Twitch. Resetting the timestamp prevents video/audio desync. 

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

