### PR TITLE
Add releaseStream command call

### DIFF
--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -256,6 +256,7 @@ open class RTMPStream: IOStream {
         addEventListener(.rtmpStatus, selector: #selector(on(status:)), observer: self)
         connection.addEventListener(.rtmpStatus, selector: #selector(on(status:)), observer: self)
         if connection.connected {
+            releaseStream()
             connection.createStream(self)
         }
         mixer.muxer = muxer
@@ -548,6 +549,7 @@ open class RTMPStream: IOStream {
         switch code {
         case RTMPConnection.Code.connectSuccess.rawValue:
             readyState = .initialized
+            releaseStream()
             connection.createStream(self)
         case RTMPStream.Code.playReset.rawValue:
             readyState = .play
@@ -562,6 +564,13 @@ open class RTMPStream: IOStream {
 }
 
 extension RTMPStream {
+    func releaseStream() {
+        guard let connection, let name = info.resourceName, connection.flashVer.contains("FMLE/") else {
+            return
+        }
+        connection.call("releaseStream", responder: nil, arguments: name)
+    }
+
     func FCPublish() {
         guard let connection, let name = info.resourceName, connection.flashVer.contains("FMLE/") else {
             return


### PR DESCRIPTION
## Description & motivation

This PR adds a `releaseStream` call that is used to release a published stream with the same name. This feature is undocumented but commonly used. For example, OBS [sends](https://github.com/obsproject/obs-studio/blob/7fab3d03e056405d4dbb5e2ed3a3f9b58e165876/plugins/obs-outputs/librtmp/rtmp.c#L3171) it before `FCPublish`. I thought to expose some interface so HK users could send it manually, however 1. HK already has undocumented `FCPublish`/`FCUnpublish` 2. When `releaseStream` isn't supported, the server will ignore it.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
