### PR TITLE
Add releaseStream support and fix FCPublish call order

### DIFF
--- a/Sources/RTMP/RTMPConnection.swift
+++ b/Sources/RTMP/RTMPConnection.swift
@@ -343,6 +343,7 @@ public class RTMPConnection: EventDispatcher {
     func createStream(_ stream: RTMPStream) {
         if let resourceName {
             call("releaseStream", responder: nil, arguments: resourceName)
+            call("FCPublish", responder: nil, arguments: resourceName)
         }
         let responder = RTMPResponder(result: { data -> Void in
             guard let id = data[0] as? Double else {

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -470,7 +470,6 @@ open class RTMPStream: IOStream {
             videoWasSent = false
             audioWasSent = false
             dataTimestamps.removeAll()
-            FCPublish()
         case .publishing:
             let metadata = makeMetaData()
             send(handlerName: "@setDataFrame", arguments: "onMetaData", metadata)
@@ -568,13 +567,6 @@ open class RTMPStream: IOStream {
 }
 
 extension RTMPStream {
-    func FCPublish() {
-        guard let connection, let name = info.resourceName, connection.flashVer.contains("FMLE/") else {
-            return
-        }
-        connection.call("FCPublish", responder: nil, arguments: name)
-    }
-
     func FCUnpublish() {
         guard let connection, let name = info.resourceName, connection.flashVer.contains("FMLE/") else {
             return


### PR DESCRIPTION
## Description & motivation

This PR allows the library users to be able to call code before `createStream`. For example, to call `releaseStream` which is supported by Wowza. New state is required because `.initialized` is the default state and when the connection is successful, changing the ready state [here](https://github.com/shogo4405/HaishinKit.swift/blob/2e4171e4f96ec0bee51de70edd9fb235e63e1fd7/Sources/RTMP/RTMPStream.swift#L550) doesn't lead to the delegate notification call. In addition, `createStream` is wrapped into a lock queue, so library users have time to perform extra calls on the same queue before the create stream execution. It also adds an additional `send` method to allow `connection.call` method call from the outside.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

