### PR TITLE
Support FMLE-compatible sequences(releaseStream/FCPublish)

### DIFF
--- a/Examples/iOS/NetStreamSwitcher.swift
+++ b/Examples/iOS/NetStreamSwitcher.swift
@@ -59,6 +59,8 @@ final class NetStreamSwitcher {
             guard let connection = connection as? RTMPConnection else {
                 return
             }
+            // Performing operations for FMLE compatibility purposes.
+            (stream as? RTMPStream)?.fcPublishName = Preference.defaultInstance.streamName
             connection.addEventListener(.rtmpStatus, selector: #selector(rtmpStatusHandler), observer: self)
             connection.addEventListener(.ioError, selector: #selector(rtmpErrorHandler), observer: self)
             connection.connect(uri)

--- a/Sources/RTMP/RTMPConnection.swift
+++ b/Sources/RTMP/RTMPConnection.swift
@@ -3,6 +3,8 @@ import Foundation
 
 /// The RTMPResponder class provides to use handle RTMPConnection's callback.
 open class RTMPResponder {
+    static let empty = RTMPResponder(result: { _ in })
+
     /// A Handler represents RTMPResponder's callback function.
     public typealias Handler = (_ data: [Any?]) -> Void
 
@@ -338,6 +340,11 @@ public class RTMPConnection: EventDispatcher {
     }
 
     func createStream(_ stream: RTMPStream) {
+        if let fcPublishName = stream.fcPublishName {
+            // FMLE-compatible sequences
+            call("releaseStream", responder: RTMPResponder.empty, arguments: fcPublishName)
+            call("FCPublish", responder: RTMPResponder.empty, arguments: fcPublishName)
+        }
         let responder = RTMPResponder(result: { data -> Void in
             guard let id = data[0] as? Double else {
                 return

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -230,6 +230,9 @@ open class RTMPStream: IOStream {
             }
         }
     }
+    /// Specifies the stream name used for FMLE-compatible sequences.
+    public var fcPublishName: String?
+
     var id: UInt32 = RTMPStream.defaultID
     var audioTimestamp: Double = 0.0
     var videoTimestamp: Double = 0.0
@@ -248,9 +251,10 @@ open class RTMPStream: IOStream {
     private weak var connection: RTMPConnection?
 
     /// Creates a new stream.
-    public init(connection: RTMPConnection) {
+    public init(connection: RTMPConnection, fcPublishName: String? = nil) {
         self.connection = connection
         super.init()
+        self.fcPublishName = fcPublishName
         dispatcher = EventDispatcher(target: self)
         connection.streams.append(self)
         addEventListener(.rtmpStatus, selector: #selector(on(status:)), observer: self)
@@ -470,7 +474,6 @@ open class RTMPStream: IOStream {
             videoWasSent = false
             audioWasSent = false
             dataTimestamps.removeAll()
-            FCPublish()
         case .publishing:
             let metadata = makeMetaData()
             send(handlerName: "@setDataFrame", arguments: "onMetaData", metadata)
@@ -568,13 +571,6 @@ open class RTMPStream: IOStream {
 }
 
 extension RTMPStream {
-    func FCPublish() {
-        guard let connection, let name = info.resourceName, connection.flashVer.contains("FMLE/") else {
-            return
-        }
-        connection.call("FCPublish", responder: nil, arguments: name)
-    }
-
     func FCUnpublish() {
         guard let connection, let name = info.resourceName, connection.flashVer.contains("FMLE/") else {
             return


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- refs https://github.com/shogo4405/HaishinKit.swift/pull/1391
- I've added support for FMLE-compatible sequences. It seems that previously, we were not calling releaseStream and had the wrong order for FCPublish.
  - These are not part of the RTMP specification and are provided as RCP features of FMS. It's unclear whether server-side implementations in modern times also have business logic implemented as stubs for these functionalities.

I anticipate usage like this: Please set stream.fcPublishName before calling RTMPConnection.connect.
```
stream = RTMPStream(connection, “ingest-stream-name”)
stream.fcPublishName = “ingest-stream-name”
stream.publish(stream.fcPublishName)
```


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

