### PR TITLE
Support attachVideo() for visionOS.

### DIFF
--- a/Examples/visionOS/ContentView.swift
+++ b/Examples/visionOS/ContentView.swift
@@ -1,5 +1,3 @@
-import RealityKit
-import RealityKitContent
 import SwiftUI
 
 struct ContentView: View {

--- a/Sources/Extension/AVCaptureDevice+Extension.swift
+++ b/Sources/Extension/AVCaptureDevice+Extension.swift
@@ -1,5 +1,3 @@
-#if os(iOS) || os(tvOS) || os(macOS)
-
 import AVFoundation
 import Foundation
 
@@ -21,5 +19,3 @@ extension AVCaptureDevice {
         }
     }
 }
-
-#endif

--- a/Sources/Extension/AVCaptureDevice.Format+Extension.swift
+++ b/Sources/Extension/AVCaptureDevice.Format+Extension.swift
@@ -14,9 +14,14 @@ extension AVCaptureDevice.Format {
         return true
     }
 }
+#elseif os(visionOS)
+extension AVCaptureDevice.Format {
+    var isMultiCamSupported: Bool {
+        return false
+    }
+}
 #endif
 
-#if os(iOS) || os(tvOS) || os(macOS)
 @available(tvOS 17.0, *)
 extension AVCaptureDevice.Format {
     func isFrameRateSupported(_ frameRate: Float64) -> Bool {
@@ -42,4 +47,3 @@ extension AVCaptureDevice.Format {
         return false
     }
 }
-#endif

--- a/Sources/Extension/AVCaptureSession+Extension.swift
+++ b/Sources/Extension/AVCaptureSession+Extension.swift
@@ -17,7 +17,8 @@ extension AVCaptureSession {
         }
     }
 }
-#elseif os(iOS) || os(tvOS) || os(macOS)
+#endif
+
 @available(tvOS 17.0, *)
 extension AVCaptureSession {
     @available(iOS, obsoleted: 16.0)
@@ -35,5 +36,4 @@ extension AVCaptureSession {
         }
     }
 }
-#endif
 // swiftlint:enable unused_setter_value

--- a/Sources/Extension/AVFrameRateRange+Extension.swift
+++ b/Sources/Extension/AVFrameRateRange+Extension.swift
@@ -1,7 +1,6 @@
 import AVFoundation
 import Foundation
 
-#if os(iOS) || os(tvOS) || os(macOS)
 @available(tvOS 17.0, *)
 extension AVFrameRateRange {
     func clamp(rate: Float64) -> Float64 {
@@ -12,4 +11,3 @@ extension AVFrameRateRange {
         (minFrameRate...maxFrameRate) ~= frameRate
     }
 }
-#endif

--- a/Sources/IO/IOCaptureUnit.swift
+++ b/Sources/IO/IOCaptureUnit.swift
@@ -1,4 +1,3 @@
-#if os(iOS) || os(tvOS) || os(macOS)
 import AVFoundation
 import Foundation
 
@@ -14,4 +13,3 @@ protocol IOCaptureUnit {
     var output: Output? { get set }
     var connection: AVCaptureConnection? { get set }
 }
-#endif


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
I have implemented support for AVCaptureSession on visionOS, as it is available. However, unfortunately, APIs such as https://developer.apple.com/documentation/avfoundation/avcaptureaudiodataoutput/ are not available on visionOS, so the attachAudio functionality could not be opened.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

