### PR TITLE
Remove default IOStream: SCStreamOutput extension.

### DIFF
--- a/Examples/macOS/SCStreamPublishViewController.swift
+++ b/Examples/macOS/SCStreamPublishViewController.swift
@@ -85,3 +85,19 @@ extension SCStreamPublishViewController: SCStreamDelegate {
         print(error)
     }
 }
+
+extension IOStream: SCStreamOutput {
+    @available(macOS 12.3, *)
+    public func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
+        if #available(macOS 13.0, *) {
+            switch type {
+            case .screen:
+                append(sampleBuffer)
+            default:
+                append(sampleBuffer)
+            }
+        } else {
+            append(sampleBuffer)
+        }
+    }
+}

--- a/Sources/IO/IOStream.swift
+++ b/Sources/IO/IOStream.swift
@@ -4,9 +4,6 @@ import CoreMedia
 #if canImport(SwiftPMSupport)
 import SwiftPMSupport
 #endif
-#if canImport(ScreenCaptureKit)
-import ScreenCaptureKit
-#endif
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -558,20 +555,3 @@ extension IOStream: IOScreenCaptureUnitDelegate {
     }
 }
 
-#if os(macOS)
-extension IOStream: SCStreamOutput {
-    @available(macOS 12.3, *)
-    public func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
-        if #available(macOS 13.0, *) {
-            switch type {
-            case .screen:
-                append(sampleBuffer)
-            default:
-                append(sampleBuffer)
-            }
-        } else {
-            append(sampleBuffer)
-        }
-    }
-}
-#endif


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- Decided to remove extensions related to SCStreamOutput as we deemed them unnecessary at the framework layer.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

