### PR TITLE
Fixed typo and removed duplicated audio format flag

### DIFF
--- a/Sources/Codec/AudioCodecSettings.swift
+++ b/Sources/Codec/AudioCodecSettings.swift
@@ -8,7 +8,7 @@ public struct AudioCodecSettings: Codable {
     /// Maximum number of channels supported by the system
     public static let maximumNumberOfChannels: UInt32 = 2
     /// Maximum sampleRate supported by the system
-    public static let mamimumSampleRate: Float64 = 48000.0
+    public static let maximumSampleRate: Float64 = 48000.0
 
     /// The type of the AudioCodec supports format.
     enum Format: Codable {
@@ -31,7 +31,7 @@ public struct AudioCodecSettings: Codable {
             case .aac:
                 return UInt32(MPEG4ObjectID.AAC_LC.rawValue)
             case .pcm:
-                return kAudioFormatFlagIsNonInterleaved | kAudioFormatFlagIsPacked | kAudioFormatFlagIsFloat | kAudioFormatFlagIsNonInterleaved
+                return kAudioFormatFlagIsNonInterleaved | kAudioFormatFlagIsPacked | kAudioFormatFlagIsFloat
             }
         }
 

--- a/Sources/IO/IOAudioResampler.swift
+++ b/Sources/IO/IOAudioResampler.swift
@@ -55,7 +55,7 @@ struct IOAudioResamplerSettings {
         }
         return .init(
             commonFormat: inputFormat.commonFormat,
-            sampleRate: min(sampleRate == 0 ? inputFormat.sampleRate : sampleRate, AudioCodecSettings.mamimumSampleRate),
+            sampleRate: min(sampleRate == 0 ? inputFormat.sampleRate : sampleRate, AudioCodecSettings.maximumSampleRate),
             channels: min(channels == 0 ? inputFormat.channelCount : channels, AudioCodecSettings.maximumNumberOfChannels),
             interleaved: inputFormat.isInterleaved
         )


### PR DESCRIPTION
Public interface typo fix

## Description & motivation

Code Cleanup 

## Type of change
Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

It is public interface variable name change. (`mamimumSampleRate` -> `maximumSampleRate`)
