### PR TITLE
fix initialization of PSI in TSWriter

### DIFF
--- a/Sources/ISO/TSWriter.swift
+++ b/Sources/ISO/TSWriter.swift
@@ -85,7 +85,7 @@ public final class TSWriter {
     private var audioTimestamp: CMTime = .invalid
     private var PCRTimestamp = CMTime.zero
     private var canWriteFor: Bool {
-        guard expectedMedias.isEmpty else {
+        guard !expectedMedias.isEmpty else {
             return true
         }
         if expectedMedias.contains(.audio) && expectedMedias.contains(.video) {
@@ -169,7 +169,7 @@ public final class TSWriter {
         if duration <= segmentDuration {
             return
         }
-        writeProgram()
+        writeProgramIfNeeded()
         rotatedTimestamp = timestamp
         delegate?.writer(self, didRotateFileHandle: timestamp)
     }


### PR DESCRIPTION
* Fix: initialization of PSI (PMT) in TSWriter for a SRTStream

## Description & motivation

When a SRT stream start, application must send PSI.
In your implementation, HaishinKit TSWriter must wait to receive both audio and video configuration (when both are required) before sending the PSI.
Unfortunately that part has a bug and PSI are sent right away (without waiting for the video configuration)

## Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)
