### PR TITLE
Supports AAC codec multi-channels.

### DIFF
--- a/Sources/IO/IOStreamRecorder.swift
+++ b/Sources/IO/IOStreamRecorder.swift
@@ -26,7 +26,7 @@ public final class IOStreamRecorder {
         case failedToFinishWriting(error: (any Swift.Error)?)
     }
 
-    /// The default output settings for an IOStreamRecorder.
+    /// The default output settings for a recording.
     public static let defaultSettings: [AVMediaType: [String: Any]] = [
         .audio: [
             AVFormatIDKey: Int(kAudioFormatMPEG4AAC),

--- a/Sources/RTMP/RTMPMuxer.swift
+++ b/Sources/RTMP/RTMPMuxer.swift
@@ -8,11 +8,11 @@ final class RTMPMuxer {
         didSet {
             switch stream?.readyState {
             case .publishing:
-                guard let audioFormat else {
+                guard let audioFormat, let config = AudioSpecificConfig(formatDescription: audioFormat.formatDescription) else {
                     return
                 }
                 var buffer = Data([RTMPMuxer.aac, FLVAACPacketType.seq.rawValue])
-                buffer.append(contentsOf: AudioSpecificConfig(formatDescription: audioFormat.formatDescription).bytes)
+                buffer.append(contentsOf: config.bytes)
                 stream?.doOutput(
                     .zero,
                     chunkStreamId: FLVTagType.audio.streamId,


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- The AudioCodec class now supports encoding and decoding for 3 channels to 8 channels.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

### Playback (OBS x HaishinKit)
1. [x] 2.1
2. [ ] 4.0
3. [x] 4.1
4. [ ] 5.1 //  [19, 176, 86, 229, 160] 5 bytes of data and couldn't parse it.
5. [ ] 7.1

### Ingest (HaishinKit x ffmpeg)
1. [ ] ~2.1~
2. [x] 4.0
3. [x] 4.1
4. [x] 5.1
5. [x] 7.1

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

