### PR TITLE
Fix don't call delegate methods incoming buffers.

### DIFF
--- a/Sources/IO/IOAudioMixerByMultiTrack.swift
+++ b/Sources/IO/IOAudioMixerByMultiTrack.swift
@@ -183,6 +183,7 @@ final class IOAudioMixerByMultiTrack: IOAudioMixerConvertible {
 extension IOAudioMixerByMultiTrack: IOAudioMixerTrackDelegate {
     // MARK: IOAudioMixerTrackDelegate
     func track(_ track: IOAudioMixerTrack<IOAudioMixerByMultiTrack>, didOutput audioPCMBuffer: AVAudioPCMBuffer, when: AVAudioTime) {
+        delegate?.audioMixer(self, track: track.id, didInput: audioPCMBuffer, when: when)
         guard shouldMix else {
             delegate?.audioMixer(self, didOutput: audioPCMBuffer, when: when)
             return

--- a/Sources/IO/IOAudioMixerBySingleTrack.swift
+++ b/Sources/IO/IOAudioMixerBySingleTrack.swift
@@ -56,11 +56,12 @@ final class IOAudioMixerBySingleTrack: IOAudioMixerConvertible {
 
 extension IOAudioMixerBySingleTrack: IOAudioMixerTrackDelegate {
     // MARK: IOAudioMixerTrackDelegate
-    func track(_ resampler: IOAudioMixerTrack<IOAudioMixerBySingleTrack>, didOutput buffer: AVAudioPCMBuffer, when: AVAudioTime) {
+    func track(_ track: IOAudioMixerTrack<IOAudioMixerBySingleTrack>, didOutput buffer: AVAudioPCMBuffer, when: AVAudioTime) {
+        delegate?.audioMixer(self, track: track.id, didInput: buffer, when: when)
         delegate?.audioMixer(self, didOutput: buffer.muted(settings.isMuted), when: when)
     }
 
-    func track(_ resampler: IOAudioMixerTrack<IOAudioMixerBySingleTrack>, errorOccurred error: IOAudioUnitError) {
+    func track(_ rtrack: IOAudioMixerTrack<IOAudioMixerBySingleTrack>, errorOccurred error: IOAudioUnitError) {
         delegate?.audioMixer(self, errorOccurred: error)
     }
 }

--- a/Sources/IO/IOAudioUnit.swift
+++ b/Sources/IO/IOAudioUnit.swift
@@ -159,6 +159,7 @@ extension IOAudioUnit: Running {
 extension IOAudioUnit: IOAudioMixerDelegate {
     // MARK: IOAudioMixerDelegate
     func audioMixer(_ audioMixer: any IOAudioMixerConvertible, track: UInt8, didInput buffer: AVAudioPCMBuffer, when: AVAudioTime) {
+        mixer?.audioUnit(self, track: track, didInput: buffer, when: when)
     }
 
     func audioMixer(_ audioMixer: any IOAudioMixerConvertible, errorOccurred error: IOAudioUnitError) {

--- a/Sources/IO/IOVideoMixer.swift
+++ b/Sources/IO/IOVideoMixer.swift
@@ -83,6 +83,7 @@ final class IOVideoMixer<T: IOVideoMixerDelegate> {
     }
 
     func append(_ track: UInt8, sampleBuffer: CMSampleBuffer, isVideoMirrored: Bool) {
+        delegate?.videoMixer(self, track: track, didInput: sampleBuffer)
         if track == settings.mainTrack {
             var imageBuffer: CVImageBuffer?
             guard let buffer = sampleBuffer.imageBuffer else {


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- I fixed it because the following delegate wasn't working.
  - func stream(_ stream: IOStream, track: UInt8, didInput buffer: AVAudioBuffer, when: AVAudioTime)
  - func stream(_ stream: IOStream, track: UInt8, didInput buffer: CMSampleBuffer)

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

