### PR TITLE
onMetaData must be ECMAArray.

### DIFF
--- a/Examples/iOS/Preference.swift
+++ b/Examples/iOS/Preference.swift
@@ -1,6 +1,6 @@
 struct Preference {
     static var defaultInstance = Preference()
 
-    var uri: String? = "rtmp://192.168.1.9/live"
+    var uri: String? = "rtmp://192.168.1.6/live"
     var streamName: String? = "live"
 }

--- a/Examples/macOS/FLVAnalyzerViewController.swift
+++ b/Examples/macOS/FLVAnalyzerViewController.swift
@@ -80,8 +80,8 @@ extension FLVAnalyzerViewController: NSTableViewDelegate {
             let amf = AMF0Serializer(data: data)
             let commandName = try? amf.deserialize()
             let name = try? amf.deserialize()
-            if let array: ASObject = try? amf.deserialize() {
-                textView.string = "\(String(describing: commandName)):\(String(describing: name)):\(array.description)"
+            if let array: ASArray = try? amf.deserialize() {
+                textView.string = "\(String(describing: commandName)):\(String(describing: name)):\(array.debugDescription)"
             } else {
                 print("ERROR")
             }

--- a/Sources/RTMP/AMFFoundation.swift
+++ b/Sources/RTMP/AMFFoundation.swift
@@ -63,6 +63,11 @@ public struct ASArray {
     public init(data: [Any?]) {
         self.data = data
     }
+
+    init(_ dict: ASObject) {
+        self.dict = dict
+        self.data = .init()
+    }
 }
 
 extension ASArray: ExpressibleByArrayLiteral {
@@ -109,7 +114,7 @@ extension ASArray: ExpressibleByArrayLiteral {
 extension ASArray: CustomDebugStringConvertible {
     // MARK: CustomDebugStringConvertible
     public var debugDescription: String {
-        data.description
+        data.debugDescription + ":" + dict.debugDescription
     }
 }
 

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -248,7 +248,11 @@ open class RTMPStream: IOStream {
         return RTMPMuxer(self)
     }()
     private var messages: [RTMPCommandMessage] = []
-    private var startedAt = Date()
+    private var startedAt = Date() {
+        didSet {
+            dataTimestamps.removeAll()
+        }
+    }
     private var dispatcher: (any EventDispatcherConvertible)!
     private lazy var pausedStatus = PausedStatus(self)
     private var howToPublish: RTMPStream.HowToPublish = .live
@@ -466,15 +470,15 @@ open class RTMPStream: IOStream {
                 connection.socket?.doOutput(chunk: RTMPChunk(message: message))
             }
             messages.removeAll()
-        case .play:
+        case .playing:
             startedAt = .init()
         case .publish:
             bitrateStrategy.setUp()
             startedAt = .init()
-            dataTimestamps.removeAll()
         case .publishing:
+            startedAt = .init()
             let metadata = makeMetaData()
-            send(handlerName: "@setDataFrame", arguments: "onMetaData", metadata)
+            send(handlerName: "@setDataFrame", arguments: "onMetaData", ASArray(metadata))
             self.metadata = metadata
         default:
             break

--- a/Tests/RTMP/AMF0SerializerTests.swift
+++ b/Tests/RTMP/AMF0SerializerTests.swift
@@ -57,4 +57,16 @@ final class AMF0SerializerTests: XCTestCase {
             }
         }
     }
+
+    func testASArray() {
+        var array = ASArray()
+        array["hello"] = "world"
+        array["world"] = "hello"
+        var amf: any AMFSerializer = AMF0Serializer()
+        amf.serialize(array)
+        amf.position = 0
+        let result: ASArray = try! amf.deserialize()
+        XCTAssertEqual(array["hello"] as? String, result["hello"] as? String)
+        XCTAssertEqual(array["world"] as? String, result["world"] as? String)
+    }
 }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
Until now, I have been sending using ECMAObject, but according to the specifications, ECMAArray is correct. I have been mistaken since the release of HaishinKit, but I have made this change to follow Enhanced RTMP.

- https://github.com/veovera/enhanced-rtmp/blob/main/docs/enhanced/enhanced-rtmp-v2.md
> To signal FLV metadata, the item within the ScriptTagBody MUST encapsulate the method name onMetaData, along with a single argument of type ECMA array. 

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

