### PR TITLE
Since isVideoMirrored is now working on macOS, discontinue the workaround.

### DIFF
--- a/Sources/Extension/CVPixelBuffer+Extension.swift
+++ b/Sources/Extension/CVPixelBuffer+Extension.swift
@@ -77,25 +77,6 @@ extension CVPixelBuffer {
         return self
     }
 
-    @discardableResult
-    func reflectHorizontal() -> Self {
-        guard var imageBuffer = try? makevImage_Buffer(format: &Self.format) else {
-            return self
-        }
-        defer {
-            imageBuffer.free()
-        }
-        guard
-            vImageHorizontalReflect_ARGB8888(
-                &imageBuffer,
-                &imageBuffer,
-                vImage_Flags(kvImageLeaveAlphaUnchanged)) == kvImageNoError else {
-            return self
-        }
-        imageBuffer.copy(to: self, format: &Self.format)
-        return self
-    }
-
     func makevImage_Buffer(format: inout vImage_CGImageFormat) throws -> vImage_Buffer {
         var buffer = vImage_Buffer()
         let cvImageFormat = vImageCVImageFormat_CreateWithCVPixelBuffer(self).takeRetainedValue()

--- a/Sources/IO/IOVideoCaptureUnit.swift
+++ b/Sources/IO/IOVideoCaptureUnit.swift
@@ -200,6 +200,6 @@ final class IOVideoCaptureUnitDataOutput: NSObject, AVCaptureVideoDataOutputSamp
     }
 
     func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
-        videoMixer.append(track, sampleBuffer: sampleBuffer, isVideoMirrored: connection.isVideoMirrored)
+        videoMixer.append(track, sampleBuffer: sampleBuffer)
     }
 }

--- a/Sources/IO/IOVideoMixer.swift
+++ b/Sources/IO/IOVideoMixer.swift
@@ -82,7 +82,7 @@ final class IOVideoMixer<T: IOVideoMixerDelegate> {
         return false
     }
 
-    func append(_ track: UInt8, sampleBuffer: CMSampleBuffer, isVideoMirrored: Bool) {
+    func append(_ track: UInt8, sampleBuffer: CMSampleBuffer) {
         delegate?.videoMixer(self, track: track, didInput: sampleBuffer)
         if track == settings.mainTrack {
             var imageBuffer: CVImageBuffer?
@@ -95,11 +95,6 @@ final class IOVideoMixer<T: IOVideoMixerDelegate> {
                 buffer.unlockBaseAddress()
                 imageBuffer?.unlockBaseAddress()
             }
-            #if os(macOS)
-            if isVideoMirrored {
-                buffer.reflectHorizontal()
-            }
-            #endif
             if let multiCamPixelBuffer = multiCamSampleBuffer?.imageBuffer {
                 multiCamPixelBuffer.lockBaseAddress()
                 switch settings.mode {

--- a/Sources/IO/IOVideoUnit.swift
+++ b/Sources/IO/IOVideoUnit.swift
@@ -165,7 +165,7 @@ final class IOVideoUnit: IOUnit {
         if buffer.formatDescription?.isCompressed == true {
             codec.append(buffer)
         } else {
-            videoMixer.append(track, sampleBuffer: buffer, isVideoMirrored: false)
+            videoMixer.append(track, sampleBuffer: buffer)
         }
     }
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- On macOS Sonoma 14.1 with an M1 Mac, isVideoMirrored was not working and did not mirror as intended, so it has been removed.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

