### PR TITLE
Implement orientation change handling for ReplayKit

### DIFF
--- a/Examples/iOS/Screencast/SampleHandler.swift
+++ b/Examples/iOS/Screencast/SampleHandler.swift
@@ -9,7 +9,12 @@ let logger = LBLogger.with(HaishinKitIdentifier)
 @available(iOS 10.0, *)
 open class SampleHandler: RPBroadcastSampleHandler {
     private var slider: UISlider?
-    private var rotator = VideoRotator()
+    private var _rotator: Any?
+    @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
+    private var rotator: VideoRotator? {
+        get { _rotator as? VideoRotator }
+        set { _rotator = newValue }
+    }
 
     private lazy var rtmpConnection: RTMPConnection = {
         let conneciton = RTMPConnection()

--- a/HaishinKit.xcodeproj/project.pbxproj
+++ b/HaishinKit.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		2EC97B7227880FF400D8BE32 /* OnTapGestureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC97B6E27880FF400D8BE32 /* OnTapGestureView.swift */; };
 		2EC97B7327880FF400D8BE32 /* Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC97B6F27880FF400D8BE32 /* Views.swift */; };
 		2EC97B7427880FF400D8BE32 /* MTHKSwiftUiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC97B7027880FF400D8BE32 /* MTHKSwiftUiView.swift */; };
+		B31723602C0940D800C7AED0 /* VideoRotator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B317235F2C0940D800C7AED0 /* VideoRotator.swift */; };
+		B31723622C0948E300C7AED0 /* VTRotationSessionOption+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B31723612C0948E300C7AED0 /* VTRotationSessionOption+Extension.swift */; };
 		B34239852B9FD3E30068C3FB /* AudioNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34239842B9FD3E30068C3FB /* AudioNode.swift */; };
 		BC0394562AA8A384006EDE38 /* Logboard.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC34DFD125EBB12C005F975A /* Logboard.xcframework */; };
 		BC03945F2AA8AFF5006EDE38 /* ExpressibleByIntegerLiteral+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC03945E2AA8AFF5006EDE38 /* ExpressibleByIntegerLiteral+ExtensionTests.swift */; };
@@ -563,6 +565,8 @@
 		2EC97B6E27880FF400D8BE32 /* OnTapGestureView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnTapGestureView.swift; sourceTree = "<group>"; };
 		2EC97B6F27880FF400D8BE32 /* Views.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Views.swift; sourceTree = "<group>"; };
 		2EC97B7027880FF400D8BE32 /* MTHKSwiftUiView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MTHKSwiftUiView.swift; sourceTree = "<group>"; };
+		B317235F2C0940D800C7AED0 /* VideoRotator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRotator.swift; sourceTree = "<group>"; };
+		B31723612C0948E300C7AED0 /* VTRotationSessionOption+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VTRotationSessionOption+Extension.swift"; sourceTree = "<group>"; };
 		B34239842B9FD3E30068C3FB /* AudioNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioNode.swift; sourceTree = "<group>"; };
 		B3D687812B80302B00E6A28E /* IOAudioMixer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IOAudioMixer.swift; sourceTree = "<group>"; };
 		BC03945E2AA8AFF5006EDE38 /* ExpressibleByIntegerLiteral+ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExpressibleByIntegerLiteral+ExtensionTests.swift"; sourceTree = "<group>"; };
@@ -1161,6 +1165,7 @@
 				BC110252292DD6E900D48035 /* vImage_Buffer+Extension.swift */,
 				BC83A4722403D83B006BDE06 /* VTCompressionSession+Extension.swift */,
 				BC4914AD28DDF445009E2DF6 /* VTDecompressionSession+Extension.swift */,
+				B31723612C0948E300C7AED0 /* VTRotationSessionOption+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1245,6 +1250,7 @@
 				BC3004CD296B0A1700119932 /* Shape.swift */,
 				BC6FC91D29609A6800A746EE /* ShapeFactory.swift */,
 				29B8768F1CD70AFE00FC07DA /* VideoEffect.swift */,
+				B317235F2C0940D800C7AED0 /* VideoRotator.swift */,
 			);
 			path = Screen;
 			sourceTree = "<group>";
@@ -1842,6 +1848,7 @@
 				29B876BC1CD70B3900FC07DA /* ByteArray.swift in Sources */,
 				29B876831CD70AE800FC07DA /* AudioSpecificConfig.swift in Sources */,
 				29B876961CD70AFE00FC07DA /* VideoEffect.swift in Sources */,
+				B31723602C0940D800C7AED0 /* VideoRotator.swift in Sources */,
 				BCFC51FE2AAB420700014428 /* IOAudioMixerTrack.swift in Sources */,
 				BC34836A2AC56F3A002926F1 /* IOVideoMixer.swift in Sources */,
 				29B876691CD70AB300FC07DA /* Constants.swift in Sources */,
@@ -1869,6 +1876,7 @@
 				BC7C56B7299E579F00C41A9B /* AudioCodecSettings.swift in Sources */,
 				29B876AC1CD70B2800FC07DA /* AMF3Serializer.swift in Sources */,
 				BC31DBD22A653D1600C4DEA3 /* IOAudioMonitor.swift in Sources */,
+				B31723622C0948E300C7AED0 /* VTRotationSessionOption+Extension.swift in Sources */,
 				BCB976DF26107B5600C9A649 /* TSField.swift in Sources */,
 				BC11024A2925147300D48035 /* IOCaptureUnit.swift in Sources */,
 				29B876921CD70AFE00FC07DA /* IOMixer.swift in Sources */,

--- a/Sources/Extension/CVPixelBuffer+Extension.swift
+++ b/Sources/Extension/CVPixelBuffer+Extension.swift
@@ -24,6 +24,10 @@ extension CVPixelBuffer {
         CVPixelBufferGetHeight(self)
     }
 
+    var formatType: OSType {
+        CVPixelBufferGetPixelFormatType(self)
+    }
+
     @discardableResult
     func over(_ pixelBuffer: CVPixelBuffer?, regionOfInterest roi: CGRect = .zero, radius: CGFloat = 0.0) -> Self {
         guard var inputImageBuffer = try? pixelBuffer?.makevImage_Buffer(format: &Self.format) else {

--- a/Sources/Extension/VTRotationSessionOption+Extension.swift
+++ b/Sources/Extension/VTRotationSessionOption+Extension.swift
@@ -1,0 +1,31 @@
+import Foundation
+import VideoToolbox
+
+struct VTRotationSessionOptionKey {
+    @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
+    static let rotation = VTRotationSessionOptionKey(CFString: kVTPixelRotationPropertyKey_Rotation)
+
+    let CFString: CFString
+}
+
+struct VTRotationSessionOptionValue {
+    @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
+    static let _90 = VTRotationSessionOptionValue(CFString: kVTRotation_CW90)
+    @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
+    static let _180 = VTRotationSessionOptionValue(CFString: kVTRotation_180)
+    @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
+    static let _270 = VTRotationSessionOptionValue(CFString: kVTRotation_CCW90)
+
+    let CFString: CFString
+}
+
+struct VTRotationSessionOption {
+    let key: VTRotationSessionOptionKey
+    let value: VTRotationSessionOptionValue
+}
+
+extension VTPixelRotationSession {
+    func setOption(_ option: VTRotationSessionOption) -> OSStatus {
+        VTSessionSetProperty(self, key: option.key.CFString, value: option.value.CFString)
+    }
+}

--- a/Sources/Screen/VideoRotator.swift
+++ b/Sources/Screen/VideoRotator.swift
@@ -1,0 +1,173 @@
+import CoreImage
+import Foundation
+import ReplayKit
+import VideoToolbox
+
+public enum VideoRotatorError: Error {
+    case noImageBuffer
+    case noOrientationInfo
+    case unsupportedOrientation
+    case cannotAllocatePixelBuffer(CVReturn)
+    case rotationFailure(OSStatus)
+}
+
+public class VideoRotator {
+    private var pixelInfo = PixelInfo.zero {
+        didSet {
+            guard pixelInfo != oldValue else {
+                return
+            }
+            rotationPixelBuffer = nil
+            pixelBufferStatus = CVPixelBufferCreate(
+                kCFAllocatorDefault,
+                pixelInfo.width,
+                pixelInfo.height,
+                pixelInfo.format,
+                nil,
+                &rotationPixelBuffer
+            )
+        }
+    }
+    private var rotationPixelBuffer: CVPixelBuffer?
+    private var pixelBufferStatus: CVReturn = kCVReturnSuccess
+    private let session: VTPixelRotationSession
+
+    public init?() {
+        guard #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) else {
+            return nil
+        }
+        var session: VTPixelRotationSession?
+        let status = VTPixelRotationSessionCreate(kCFAllocatorDefault, &session)
+        guard status == noErr, let session else {
+            return nil
+        }
+        self.session = session
+    }
+
+    @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
+    public func rotate(buffer sampleBuffer: CMSampleBuffer) -> Result<CMSampleBuffer, VideoRotatorError> {
+        guard let buffer = sampleBuffer.imageBuffer else {
+            return .failure(.noImageBuffer)
+        }
+        buffer.lockBaseAddress()
+        defer {
+            buffer.unlockBaseAddress()
+        }
+        var orientation: CGImagePropertyOrientation?
+        orientation = sampleBuffer.orientation
+        guard let orientation else {
+            return .failure(.noOrientationInfo)
+        }
+        guard orientation != .up else {
+            return .success(sampleBuffer)
+        }
+        var status: OSStatus
+        switch orientation {
+        case .left:
+            status = session.setOption(.init(key: .rotation, value: ._90))
+        case .down:
+            status = session.setOption(.init(key: .rotation, value: ._180))
+        case .right:
+            status = session.setOption(.init(key: .rotation, value: ._270))
+        default:
+            return .failure(.unsupportedOrientation)
+        }
+        guard status == noErr else {
+            return .failure(.rotationFailure(status))
+        }
+        switch orientation {
+        case .up, .down:
+            pixelInfo = .init(width: buffer.width, height: buffer.height, format: buffer.formatType)
+        case .left, .right:
+            pixelInfo = .init(width: buffer.height, height: buffer.width, format: buffer.formatType)
+        default:
+            return .failure(.unsupportedOrientation)
+        }
+        guard let rotationPixelBuffer else {
+            return .failure(.cannotAllocatePixelBuffer(pixelBufferStatus))
+        }
+        status = VTPixelRotationSessionRotateImage(session, buffer, rotationPixelBuffer)
+        guard status == noErr else {
+            return .failure(.rotationFailure(status))
+        }
+        var rotatedBuffer: CMSampleBuffer?
+        (rotatedBuffer, status) = createSampleBuffer(sampleBuffer, imageBuffer: rotationPixelBuffer)
+        guard let rotatedBuffer else {
+            return .failure(.rotationFailure(status))
+        }
+        return .success(rotatedBuffer)
+    }
+
+    @inline(__always)
+    private func createSampleBuffer(_ inSampleBuffer: CMSampleBuffer, imageBuffer: CVImageBuffer) -> (CMSampleBuffer?, OSStatus) {
+        var info = CMSampleTimingInfo()
+        info.presentationTimeStamp = inSampleBuffer.presentationTimeStamp
+        info.duration = CMSampleBufferGetOutputDuration(inSampleBuffer)
+        info.decodeTimeStamp = CMSampleBufferGetDecodeTimeStamp(inSampleBuffer)
+        var formatDescription: CMFormatDescription?
+        var status = CMVideoFormatDescriptionCreateForImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: imageBuffer,
+            formatDescriptionOut: &formatDescription)
+        guard status == noErr, let formatDescription else {
+            return (nil, status)
+        }
+        var outSampleBuffer: CMSampleBuffer?
+        status = CMSampleBufferCreateReadyWithImageBuffer(allocator: kCFAllocatorDefault,
+                                                          imageBuffer: imageBuffer,
+                                                          formatDescription: formatDescription,
+                                                          sampleTiming: &info,
+                                                          sampleBufferOut: &outSampleBuffer)
+
+        guard status == noErr, let outSampleBuffer else {
+            return (nil, status)
+        }
+        return (outSampleBuffer, noErr)
+    }
+}
+
+private struct PixelInfo: Hashable, Equatable, CustomStringConvertible {
+    static let zero: PixelInfo = .init(width: 0, height: 0, format: 0)
+
+    let width: Int
+    let height: Int
+    let format: OSType
+
+    static func == (lhs: PixelInfo, rhs: PixelInfo) -> Bool {
+        return lhs.width == rhs.width && lhs.height == rhs.height && lhs.format == rhs.format
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(width)
+        hasher.combine(height)
+        hasher.combine(format)
+    }
+
+    public var description: String {
+        "PixelInfo(width: \(width), height: \(height), format: \(format))"
+    }
+}
+
+private extension CMSampleBuffer {
+    var orientation: CGImagePropertyOrientation? {
+        get {
+            guard let orientationAttachment = CMGetAttachment(
+                self,
+                key: RPVideoSampleOrientationKey as CFString,
+                attachmentModeOut: nil) as? NSNumber
+            else { return nil }
+
+            return CGImagePropertyOrientation(rawValue: orientationAttachment.uint32Value)
+        }
+        set {
+            if let value = newValue {
+                CMSetAttachment(self,
+                                key: RPVideoSampleOrientationKey as CFString,
+                                value: NSNumber(value: value.rawValue),
+                                attachmentMode: kCMAttachmentMode_ShouldNotPropagate)
+            } else {
+                CMRemoveAttachment(self, key: RPVideoSampleOrientationKey as CFString)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description & motivation

This PR adds a feature to rotate pixel buffers that come from ReplayKit. This allows to rotate video when device changes orientation. It is much more efficient than using `VideoEffect`. 

Rotation has two modes besides default `.disabled`.
####  Automatic:
```Swift
rtmpStream.videoMixerSettings.propogateReplayKitOrientation = true
rtmpStream.videoSettings.rotationMode = .automatic
```
In this case `VideoCodec` automatically determines the required rotation based on the buffer orientation.

#### Manual:
```Swift
rtmpStream.videoSettings.rotationMode = ._90
```

This allows HK users to specify rotation manually.

## Notes
* I decided to store rotation information in the `CVImageBuffer` so there is no need to modify `VideoCodec` method signatures. As result, `IOVideoMixer` saves the orientation info as an attachment of the pixel buffer. It is only required for `.automatic` mode.
* `CVPixelBufferPool` leaks in iOS 17.5. When pool reference is set to `nil`, it keeps circular reference to itself and allocated pixel buffers are also getting retained. That's why I'm not using pool to allocate `rotationPixelBuffer`. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
