### PR TITLE
Add maximumNumberOfChannels property.

### DIFF
--- a/Sources/IO/IOAudioMixerSettings.swift
+++ b/Sources/IO/IOAudioMixerSettings.swift
@@ -30,6 +30,10 @@ public struct IOAudioMixerSettings {
     /// Specifies the track settings.
     public var tracks: [UInt8: IOAudioMixerTrackSettings] = .init()
 
+    /// Specifies the maximum number of channels supported by the system
+    /// - Description: The maximum number of channels to be used when the number of channels is 0 (not set). More than 2 channels are not supported by the service. It is defined to prevent audio issues since recording does not support more than 2 channels.
+    public var maximumNumberOfChannels: UInt32 = 2
+
     /// Creates a new instance of a settings.
     public init(
         sampleRate: Float64 = 0,
@@ -49,7 +53,7 @@ public struct IOAudioMixerSettings {
             return nil
         }
         let sampleRate = min(sampleRate == 0 ? format.sampleRate : sampleRate, Self.maximumSampleRate)
-        let channelCount = channels == 0 ? format.channelCount : channels
+        let channelCount = channels == 0 ? min(format.channelCount, maximumNumberOfChannels) : channels
         if let channelLayout = AVAudioUtil.makeChannelLayout(channelCount) {
             return .init(
                 commonFormat: Self.commonFormat,

--- a/Tests/IO/IOAudioMixerBySingleTrackTests.swift
+++ b/Tests/IO/IOAudioMixerBySingleTrackTests.swift
@@ -47,7 +47,7 @@ final class IOAudioMixerBySingleTrackTests: XCTestCase {
         XCTAssertEqual(mixer.outputFormat?.sampleRate, 48000)
     }
 
-    func test44100to48000_4ch() {
+    func test44100to48000_4ch_2ch() {
         let result = Result()
         let mixer = IOAudioMixerBySingleTrack()
         mixer.delegate = result
@@ -55,11 +55,33 @@ final class IOAudioMixerBySingleTrackTests: XCTestCase {
             sampleRate: 44100, channels: 0
         )
         mixer.append(0, buffer: CMAudioSampleBufferFactory.makeSinWave(48000, numSamples: 1024, channels: 4)!)
+        XCTAssertEqual(mixer.outputFormat?.channelCount, 2)
+        XCTAssertEqual(mixer.outputFormat?.sampleRate, 44100)
+        mixer.settings = .init(
+            sampleRate: 48000, channels: 0
+        )
+        mixer.append(0, buffer: CMAudioSampleBufferFactory.makeSinWave(44100, numSamples: 1024, channels: 4)!)
+        mixer.append(0, buffer: CMAudioSampleBufferFactory.makeSinWave(44100, numSamples: 1024, channels: 4)!)
+        XCTAssertEqual(mixer.outputFormat?.channelCount, 2)
+        XCTAssertEqual(mixer.outputFormat?.sampleRate, 48000)
+        XCTAssertEqual(result.outputs.count, 2)
+    }
+
+    func test44100to48000_4ch() {
+        let result = Result()
+        let mixer = IOAudioMixerBySingleTrack()
+        mixer.delegate = result
+        mixer.settings = .init(
+            sampleRate: 44100, channels: 0
+        )
+        mixer.settings.maximumNumberOfChannels = 4
+        mixer.append(0, buffer: CMAudioSampleBufferFactory.makeSinWave(48000, numSamples: 1024, channels: 4)!)
         XCTAssertEqual(mixer.outputFormat?.channelCount, 4)
         XCTAssertEqual(mixer.outputFormat?.sampleRate, 44100)
         mixer.settings = .init(
             sampleRate: 48000, channels: 0
         )
+        mixer.settings.maximumNumberOfChannels = 4
         mixer.append(0, buffer: CMAudioSampleBufferFactory.makeSinWave(44100, numSamples: 1024, channels: 4)!)
         mixer.append(0, buffer: CMAudioSampleBufferFactory.makeSinWave(44100, numSamples: 1024, channels: 4)!)
         XCTAssertEqual(mixer.outputFormat?.channelCount, 4)


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- I have enabled support for more than 2 channels on our end, but since some services may not support this, I have changed the default to handle up to 2 channels. https://github.com/shogo4405/HaishinKit.swift/pull/1432

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

