### PR TITLE
Change how track volume is applied

### DIFF
--- a/Sources/IO/IOAudioMixerByMultiTrack.swift
+++ b/Sources/IO/IOAudioMixerByMultiTrack.swift
@@ -103,12 +103,11 @@ final class IOAudioMixerByMultiTrack: IOAudioMixerConvertible {
         let mixerNode = try MixerNode(format: outputFormat)
         try mixerNode.update(busCount: tracks.count, scope: .input)
         let busCount = try mixerNode.busCount(scope: .input)
-        if busCount > tracks.count {
-            for index in tracks.count..<busCount {
-                try mixerNode.enable(bus: UInt8(index), scope: .input, isEnabled: false)
-            }
+        for index in 0..<busCount {
+            try mixerNode.enable(bus: UInt8(index), scope: .input, isEnabled: false)
         }
         for (bus, track) in tracks {
+            try mixerNode.enable(bus: bus, scope: .input, isEnabled: true)
             try mixerNode.update(format: outputFormat, bus: bus, scope: .input)
             var callbackStruct = AURenderCallbackStruct(inputProc: inputRenderCallback,
                                                         inputProcRefCon: Unmanaged.passUnretained(self).toOpaque())

--- a/Sources/IO/IOAudioMixerByMultiTrack.swift
+++ b/Sources/IO/IOAudioMixerByMultiTrack.swift
@@ -108,12 +108,12 @@ final class IOAudioMixerByMultiTrack: IOAudioMixerConvertible {
                 try mixerNode.enable(bus: UInt8(index), scope: .input, isEnabled: false)
             }
         }
-        for (bus, _) in tracks {
+        for (bus, track) in tracks {
             try mixerNode.update(format: outputFormat, bus: bus, scope: .input)
             var callbackStruct = AURenderCallbackStruct(inputProc: inputRenderCallback,
                                                         inputProcRefCon: Unmanaged.passUnretained(self).toOpaque())
             try mixerNode.update(inputCallback: &callbackStruct, bus: bus)
-            try mixerNode.update(volume: 1, bus: bus, scope: .input)
+            try mixerNode.update(volume: track.settings.volume, bus: bus, scope: .input)
         }
         try mixerNode.update(format: outputFormat, bus: 0, scope: .output)
         try mixerNode.update(volume: 1, bus: 0, scope: .output)


### PR DESCRIPTION
## Description & motivation

When `settings` are applied to `IOAudioMixerByMultiTrack` before it receives an audio buffer, `mixerNode` is not initialized. This fix applies the volume during the node creation. Second issue is related to using non-sequential track numbers. For example, 0 for microphone, 2 for screensharing app audio. This results to only tracks 0, 1 being enabled and 2 being disabled. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

