### PR TITLE
Remove shouldMix from multitrack mixer

### DIFF
--- a/Sources/IO/IOAudioMixerByMultiTrack.swift
+++ b/Sources/IO/IOAudioMixerByMultiTrack.swift
@@ -40,7 +40,6 @@ final class IOAudioMixerByMultiTrack: IOAudioMixerConvertible {
     }
     private var tracks: [UInt8: IOAudioMixerTrack<IOAudioMixerByMultiTrack>] = [:] {
         didSet {
-            shouldMix = 1 < tracks.count
             tryToSetupAudioNodes()
         }
     }
@@ -52,7 +51,6 @@ final class IOAudioMixerByMultiTrack: IOAudioMixerConvertible {
             }
         }
     }
-    private var shouldMix = false
     private var mixerNode: MixerNode?
     private var sampleTime: AVAudioFramePosition = IOAudioMixerByMultiTrack.defaultSampleTime
     private var outputNode: OutputNode?
@@ -82,9 +80,6 @@ final class IOAudioMixerByMultiTrack: IOAudioMixerConvertible {
     }
 
     private func tryToSetupAudioNodes() {
-        guard shouldMix else {
-            return
-        }
         do {
             try setupAudioNodes()
         } catch {
@@ -183,10 +178,6 @@ extension IOAudioMixerByMultiTrack: IOAudioMixerTrackDelegate {
     // MARK: IOAudioMixerTrackDelegate
     func track(_ track: IOAudioMixerTrack<IOAudioMixerByMultiTrack>, didOutput audioPCMBuffer: AVAudioPCMBuffer, when: AVAudioTime) {
         delegate?.audioMixer(self, track: track.id, didInput: audioPCMBuffer, when: when)
-        guard shouldMix else {
-            delegate?.audioMixer(self, didOutput: audioPCMBuffer, when: when)
-            return
-        }
         buffers[track.id]?.append(audioPCMBuffer, when: when)
         if settings.mainTrack == track.id {
             if sampleTime == Self.defaultSampleTime {


### PR DESCRIPTION
## Description & motivation

This PR removes `shouldMix` so it would be possible to control volume even when there's only one track.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
