### PR TITLE
Allow mid stream audio video format change 

### DIFF
--- a/Sources/RTMP/RTMPMuxer.swift
+++ b/Sources/RTMP/RTMPMuxer.swift
@@ -14,7 +14,7 @@ final class RTMPMuxer {
                 var buffer = Data([RTMPMuxer.aac, FLVAACPacketType.seq.rawValue])
                 buffer.append(contentsOf: config.bytes)
                 stream?.doOutput(
-                    .zero,
+                    oldValue == nil ? .zero : .one,
                     chunkStreamId: FLVTagType.audio.streamId,
                     message: RTMPAudioMessage(streamId: 0, timestamp: 0, payload: buffer)
                 )
@@ -42,7 +42,7 @@ final class RTMPMuxer {
                     var buffer = Data([FLVFrameType.key.rawValue << 4 | FLVVideoCodec.avc.rawValue, FLVAVCPacketType.seq.rawValue, 0, 0, 0])
                     buffer.append(configurationBox)
                     stream?.doOutput(
-                        .zero,
+                        oldValue == nil ? .zero : .one,
                         chunkStreamId: FLVTagType.video.streamId,
                         message: RTMPVideoMessage(streamId: 0, timestamp: 0, payload: buffer)
                     )
@@ -53,7 +53,7 @@ final class RTMPMuxer {
                     var buffer = Data([0b10000000 | FLVFrameType.key.rawValue << 4 | FLVVideoPacketType.sequenceStart.rawValue, 0x68, 0x76, 0x63, 0x31])
                     buffer.append(configurationBox)
                     stream?.doOutput(
-                        .zero,
+                        oldValue == nil ? .zero : .one,
                         chunkStreamId: FLVTagType.video.streamId,
                         message: RTMPVideoMessage(streamId: 0, timestamp: 0, payload: buffer)
                     )


### PR DESCRIPTION
## Description & motivation

When audio or video format is changed in the middle of the stream, the muxer sends RTMP message with zero chunk type. This breaks streams on different platforms, including Twitch. RTMPStream used to have flags `audioWasSent`, `videoWasSent` to handle this case before this 65cbf34465d69c1e733af5d9a5b81a5c2adb0ad1 change. This PR doesn't bring the flags back, instead it just checks if the format was nil. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

