### PR TITLE
Update audio track delegate on output format change

### DIFF
--- a/Sources/IO/IOAudioMixerByMultiTrack.swift
+++ b/Sources/IO/IOAudioMixerByMultiTrack.swift
@@ -27,6 +27,7 @@ final class IOAudioMixerByMultiTrack: IOAudioMixerConvertible {
             for id in tracks.keys {
                 buffers[id] = .init(outputFormat)
                 tracks[id] = .init(id: id, outputFormat: outputFormat)
+                tracks[id]?.delegate = self
             }
         }
     }


### PR DESCRIPTION
## Description & motivation

This PR fixes an issue where audio tracks from multitrack mixer don't preserve their delegates. This leads to a state where AudioCodec doesn't receive current audio format from the mixer.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
