### PR TITLE
Fix buffer rotation creation in Screencast example 

### DIFF
--- a/Examples/iOS/Screencast/SampleHandler.swift
+++ b/Examples/iOS/Screencast/SampleHandler.swift
@@ -9,7 +9,12 @@ let logger = LBLogger.with(HaishinKitIdentifier)
 @available(iOS 10.0, *)
 open class SampleHandler: RPBroadcastSampleHandler {
     private var slider: UISlider?
-    private var _rotator: Any?
+    private var _rotator: Any? = {
+        if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
+            return VideoRotator()
+        }
+        return nil
+    }()
     @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
     private var rotator: VideoRotator? {
         get { _rotator as? VideoRotator }

--- a/Examples/iOS/Screencast/SampleHandler.swift
+++ b/Examples/iOS/Screencast/SampleHandler.swift
@@ -9,18 +9,21 @@ let logger = LBLogger.with(HaishinKitIdentifier)
 @available(iOS 10.0, *)
 open class SampleHandler: RPBroadcastSampleHandler {
     private var slider: UISlider?
-    private var _rotator: Any? = {
-        if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
-            return VideoRotator()
-        }
-        return nil
-    }()
+    private var _rotator: Any?
     @available(iOS 16.0, tvOS 16.0, macOS 13.0, *)
     private var rotator: VideoRotator? {
         get { _rotator as? VideoRotator }
         set { _rotator = newValue }
     }
-
+    private var isVideoRotationEnabled = false {
+        didSet {
+            if isVideoRotationEnabled, #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
+                _rotator = VideoRotator()
+            } else {
+                _rotator = nil
+            }
+        }
+    }
     private lazy var rtmpConnection: RTMPConnection = {
         let conneciton = RTMPConnection()
         conneciton.addEventListener(.rtmpStatus, selector: #selector(rtmpStatusEvent), observer: self)
@@ -52,6 +55,8 @@ open class SampleHandler: RPBroadcastSampleHandler {
         LBLogger.with(HaishinKitIdentifier).level = .info
         // rtmpStream.audioMixerSettings = .init(sampleRate: 0, channels: 2)
         rtmpStream.audioMixerSettings.tracks[1] = .default
+        rtmpStream.videoSettings.scalingMode = .letterbox
+        isVideoRotationEnabled = true
         rtmpConnection.connect(Preference.default.uri!, arguments: nil)
         // The volume of the audioApp can be obtained even when muted. A hack to synchronize with the volume.
         DispatchQueue.main.async {


### PR DESCRIPTION
## Description & motivation

This PR fixes initialization of the buffer rotator in Screencast example. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

