### PR TITLE
implementation deleteStream.

### DIFF
--- a/Examples/iOS/Preference.swift
+++ b/Examples/iOS/Preference.swift
@@ -2,6 +2,6 @@ struct Preference: Sendable {
     // Temp
     static nonisolated(unsafe) var `default` = Preference()
 
-    var uri: String? = "rtmp://192.168.1.4/live"
+    var uri: String? = "rtmp://192.168.1.6/live"
     var streamName: String? = "live"
 }

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -501,18 +501,20 @@ open class RTMPStream: IOStream {
         readyState = .open
         if let fcPublishName {
             connection.call("FCUnpublish", responder: nil, arguments: fcPublishName)
+            connection.call("deleteStream", responder: nil, arguments: id)
+        } else {
+            connection.doOutput(chunk: RTMPChunk(
+                                    type: .zero,
+                                    streamId: RTMPChunk.StreamID.command.rawValue,
+                                    message: RTMPCommandMessage(
+                                        streamId: id,
+                                        transactionId: 0,
+                                        objectEncoding: objectEncoding,
+                                        commandName: "closeStream",
+                                        commandObject: nil,
+                                        arguments: []
+                                    )))
         }
-        connection.doOutput(chunk: RTMPChunk(
-                                type: .zero,
-                                streamId: RTMPChunk.StreamID.command.rawValue,
-                                message: RTMPCommandMessage(
-                                    streamId: 0,
-                                    transactionId: 0,
-                                    objectEncoding: self.objectEncoding,
-                                    commandName: "closeStream",
-                                    commandObject: nil,
-                                    arguments: [self.id]
-                                )))
     }
 
     func doOutput(_ type: RTMPChunkType, chunkStreamId: UInt16, message: RTMPMessage) {


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
When using FMLE-compatible mode, we have changed to use deleteStream instead of closeStream.
- refs https://github.com/shogo4405/HaishinKit.swift/pull/1517
- fixed https://github.com/shogo4405/HaishinKit.swift/discussions/1511

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:
**Expected**
<img width="1146" alt="スクリーンショット 2024-07-28 22 34 32" src="https://github.com/user-attachments/assets/6cea2420-7aca-437a-a9d3-75d9f1f4a32b">
