### PR TITLE
Make AVCaptureSession calls thread safe

### DIFF
--- a/Sources/IO/IOCaptureSession.swift
+++ b/Sources/IO/IOCaptureSession.swift
@@ -236,14 +236,6 @@ final class IOCaptureSession {
             return
         }
         let error = AVError(_nsError: errorValue)
-        switch error.code {
-        #if os(iOS) || os(tvOS)
-        case .mediaServicesWereReset:
-            startRunningIfNeeded()
-        #endif
-        default:
-            break
-        }
         delegate?.captureSession(self, sessionRuntimeError: session, error: error)
     }
 

--- a/Sources/IO/IOMixer.swift
+++ b/Sources/IO/IOMixer.swift
@@ -17,6 +17,10 @@ protocol IOMixerDelegate: AnyObject {
     @available(tvOS 17.0, *)
     func mixer(_ mixer: IOMixer, sessionInterruptionEnded session: AVCaptureSession)
     #endif
+    #if os(iOS) || os(tvOS)
+    @available(tvOS 17.0, *)
+    func mixer(_ mixer: IOMixer, mediaServicesWereReset error: AVError)
+    #endif
 }
 
 /// An object that mixies audio and video for streaming.
@@ -164,6 +168,14 @@ extension IOMixer: IOCaptureSessionDelegate {
             break
         }
         #endif
+        switch error.code {
+        #if os(iOS) || os(tvOS)
+        case .mediaServicesWereReset:
+            delegate?.mixer(self, mediaServicesWereReset: error)
+        #endif
+        default:
+            break
+        }
     }
 
     #if os(iOS) || os(tvOS) || os(visionOS)

--- a/Sources/IO/IOStream.swift
+++ b/Sources/IO/IOStream.swift
@@ -519,6 +519,16 @@ extension IOStream: IOMixerDelegate {
         delegate?.stream(self, sessionInterruptionEnded: session)
     }
     #endif
+
+    #if os(iOS) || os(tvOS)
+    @available(tvOS 17.0, *)
+    func mixer(_ mixer: IOMixer, mediaServicesWereReset error: AVError) {
+        lockQueue.async {
+            self.mixer.session.startRunningIfNeeded()
+        }
+    }
+    #endif
+
 }
 
 extension IOStream: IOTellyUnitDelegate {


### PR DESCRIPTION
## Description & motivation

This PR is a fix for #1522 to make AVCaptureSession `startRunning` and `beginConfiguration` calls thread safe.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

