### PR TITLE
Allow to render effects only on stream

### DIFF
--- a/Sources/Extension/CMSampleBuffer+Extension.swift
+++ b/Sources/Extension/CMSampleBuffer+Extension.swift
@@ -3,6 +3,8 @@ import AVFoundation
 import CoreMedia
 
 extension CMSampleBuffer {
+    static let ScreenObjectImageTarget: CFString = "ScreenObjectImageTarget" as CFString
+
     @inlinable @inline(__always) var isNotSync: Bool {
         get {
             guard !sampleAttachments.isEmpty else {
@@ -15,6 +17,28 @@ extension CMSampleBuffer {
                 return
             }
             sampleAttachments[0][.notSync] = newValue ? 1 : nil
+        }
+    }
+
+    var targetType: ScreenObject.ImageTarget? {
+        get {
+            guard let rawTargetAttachment = CMGetAttachment(
+                self,
+                key: CMSampleBuffer.ScreenObjectImageTarget as CFString,
+                attachmentModeOut: nil) as? NSNumber
+            else { return nil }
+
+            return ScreenObject.ImageTarget(rawValue: rawTargetAttachment.intValue)
+        }
+        set {
+            if let value = newValue {
+                CMSetAttachment(self,
+                                key: CMSampleBuffer.ScreenObjectImageTarget,
+                                value: NSNumber(value: value.rawValue),
+                                attachmentMode: kCMAttachmentMode_ShouldPropagate)
+            } else {
+                CMRemoveAttachment(self, key: CMSampleBuffer.ScreenObjectImageTarget)
+            }
         }
     }
 }

--- a/Sources/IO/IOVideoUnit.swift
+++ b/Sources/IO/IOVideoUnit.swift
@@ -255,14 +255,28 @@ extension IOVideoUnit: IOVideoMixerDelegate {
     }
 
     func videoMixer(_ videoMixer: IOVideoMixer<IOVideoUnit>, didOutput sampleBuffer: CMSampleBuffer) {
-        if let imageBuffer = sampleBuffer.imageBuffer {
-            codec.append(
-                imageBuffer,
-                presentationTimeStamp: sampleBuffer.presentationTimeStamp,
-                duration: sampleBuffer.duration
-            )
+        func sendToStream() {
+            if let imageBuffer = sampleBuffer.imageBuffer {
+                codec.append(
+                    imageBuffer,
+                    presentationTimeStamp: sampleBuffer.presentationTimeStamp,
+                    duration: sampleBuffer.duration
+                )
+            }
+            mixer?.videoUnit(self, didOutput: sampleBuffer)
         }
-        view?.enqueue(sampleBuffer)
-        mixer?.videoUnit(self, didOutput: sampleBuffer)
+        func sendToView() {
+            view?.enqueue(sampleBuffer)
+        }
+        let targetType = sampleBuffer.targetType ?? .both
+        switch targetType {
+        case .both:
+            sendToStream()
+            sendToView()
+        case .stream:
+            sendToStream()
+        case .view:
+            sendToView()
+        }
     }
 }

--- a/Sources/Screen/ScreenRenderer.swift
+++ b/Sources/Screen/ScreenRenderer.swift
@@ -16,7 +16,7 @@ public protocol ScreenRenderer: AnyObject {
     /// Draws a sceen object.
     func draw(_ screenObject: ScreenObject)
     /// Sets up the render target.
-    func setTarget(_ pixelBuffer: CVPixelBuffer?)
+    func setTarget(_ pixelBuffer: CVPixelBuffer?, _ targetType: ScreenObject.ImageTarget)
 }
 
 final class ScreenRendererByCPU: ScreenRenderer {
@@ -72,7 +72,9 @@ final class ScreenRendererByCPU: ScreenRenderer {
         decode: nil,
         renderingIntent: .defaultIntent)
     private var images: [ScreenObject: vImage_Buffer] = [:]
+    private var viewImages: [ScreenObject: vImage_Buffer] = [:]
     private var canvas: vImage_Buffer = .init()
+    private var viewCanvas: vImage_Buffer = .init()
     private var converter: vImageConverter?
     private var shapeFactory = ShapeFactory()
     private var pixelFormatType: OSType? {
@@ -88,7 +90,51 @@ final class ScreenRendererByCPU: ScreenRenderer {
         return try? ChromaKeyProcessor()
     }()
 
-    func setTarget(_ pixelBuffer: CVPixelBuffer?) {
+    func setTarget(_ pixelBuffer: CVPixelBuffer?, _ targetType: ScreenObject.ImageTarget = .both) {
+        guard let pixelBuffer else {
+            return
+        }
+        switch targetType {
+        case .view:
+            setTarget(pixelBuffer, &viewCanvas)
+        default:
+            setTarget(pixelBuffer, &canvas)
+        }
+    }
+
+    func layout(_ screenObject: ScreenObject) {
+        autoreleasepool {
+            let imageList = screenObject.makeImage(self)
+            for (target, image) in imageList {
+                guard let image else {
+                    continue
+                }
+                switch target {
+                case .view:
+                    layout(screenObject, image, &viewImages)
+                case .stream:
+                    layout(screenObject, image, &images)
+                case .both:
+                    layout(screenObject, image, &images)
+                    layout(screenObject, image, &viewImages)
+                }
+            }
+        }
+    }
+
+    func draw(_ screenObject: ScreenObject) {
+        let origin = screenObject.bounds.origin
+
+        if var image = images[screenObject] {
+            draw(&image, canvas, origin)
+        }
+
+        if var viewImage = viewImages[screenObject] {
+            draw(&viewImage, viewCanvas, origin)
+        }
+    }
+
+    func setTarget(_ pixelBuffer: CVPixelBuffer?, _ canvas: inout vImage_Buffer) {
         guard let pixelBuffer else {
             return
         }
@@ -122,38 +168,28 @@ final class ScreenRendererByCPU: ScreenRenderer {
         }
     }
 
-    func layout(_ screenObject: ScreenObject) {
-        autoreleasepool {
-            guard let image = screenObject.makeImage(self) else {
-                return
-            }
-            do {
-                images[screenObject]?.free()
-                var buffer = try vImage_Buffer(cgImage: image, format: format)
-                images[screenObject] = buffer
-                if 0 < screenObject.cornerRadius {
-                    if var mask = shapeFactory.cornerRadius(image.size, cornerRadius: screenObject.cornerRadius) {
-                        vImageOverwriteChannels_ARGB8888(&mask, &buffer, &buffer, 0x8, Self.noFlags)
-                    }
-                } else {
-                    if let screenObject = screenObject as? (any ChromaKeyProcessorble),
-                       let chromaKeyColor = screenObject.chromaKeyColor,
-                       var mask = try choromaKeyProcessor?.makeMask(&buffer, chromeKeyColor: chromaKeyColor) {
-                        vImageOverwriteChannels_ARGB8888(&mask, &buffer, &buffer, 0x8, Self.noFlags)
-                    }
+    private func layout(_ screenObject: ScreenObject, _ image: CGImage, _ images: inout [ScreenObject: vImage_Buffer]) {
+        do {
+            images[screenObject]?.free()
+            var buffer = try vImage_Buffer(cgImage: image, format: format)
+            images[screenObject] = buffer
+            if 0 < screenObject.cornerRadius {
+                if var mask = shapeFactory.cornerRadius(image.size, cornerRadius: screenObject.cornerRadius) {
+                    vImageOverwriteChannels_ARGB8888(&mask, &buffer, &buffer, 0x8, Self.noFlags)
                 }
-            } catch {
-                logger.error(error)
+            } else {
+                if let screenObject = screenObject as? (any ChromaKeyProcessorble),
+                   let chromaKeyColor = screenObject.chromaKeyColor,
+                   var mask = try choromaKeyProcessor?.makeMask(&buffer, chromeKeyColor: chromaKeyColor) {
+                    vImageOverwriteChannels_ARGB8888(&mask, &buffer, &buffer, 0x8, Self.noFlags)
+                }
             }
+        } catch {
+            logger.error(error)
         }
     }
 
-    func draw(_ screenObject: ScreenObject) {
-        guard var image = images[screenObject] else {
-            return
-        }
-
-        let origin = screenObject.bounds.origin
+    private func draw(_ image: inout vImage_Buffer, _ canvas: vImage_Buffer, _ origin: CGPoint) {
         let start = Int(max(0, origin.y)) * canvas.rowBytes + Int(max(0, origin.x)) * 4
 
         var destination = vImage_Buffer(


### PR DESCRIPTION
* Feature: allow to render effects only on stream

## Description & motivation

This PR follows #1530 and allows to split effects rendering to show them only on the stream and hide them on the preview. This allows things like rendering UIView as effects. The main reason I implemented the split process in the `ScreenObject` was to avoid having two screen objects and a separate root in the `Screen`. I'm looking forward for the feedback before I can polish this implementation.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:
<details>
  <summary>Preview</summary>
  
![IMG_6298](https://github.com/user-attachments/assets/996e6661-ebb6-4979-8b37-befcbf2cf561)

</details>

<details>
  <summary>Stream</summary>
  
<img width="966" alt="Screenshot 2024-08-07 at 4 16 05 PM" src="https://github.com/user-attachments/assets/e1324750-d913-437e-8854-fa2cbe58e05e">

</details>