### PR TITLE
Default constructor to the Settings-related struct.

### DIFF
--- a/Sources/Codec/AudioCodecSettings.swift
+++ b/Sources/Codec/AudioCodecSettings.swift
@@ -5,6 +5,8 @@ import Foundation
 public struct AudioCodecSettings: Codable, Sendable {
     /// The default value.
     public static let `default` = AudioCodecSettings()
+    /// The default bitRate. The value is 64,000 bps.
+    public static let defaultBitRate = 64 * 1000
     /// Maximum number of channels supported by the system
     public static let maximumNumberOfChannels: UInt32 = 8
 
@@ -131,16 +133,23 @@ public struct AudioCodecSettings: Codable, Sendable {
     }
 
     /// Specifies the bitRate of audio output.
-    public var bitRate: Int = 64 * 1000
+    public var bitRate: Int
 
     /// Specifies the mixes the channels or not.
-    public var downmix = true
+    public var downmix: Bool
 
     /// Specifies the map of the output to input channels.
     public var channelMap: [Int]?
 
     /// Specifies the output format.
     var format: AudioCodecSettings.Format = .aac
+
+    /// Creates a new instance.
+    public init(bitRate: Int = AudioCodecSettings.defaultBitRate, downmix: Bool = true, channelMap: [Int]? = nil) {
+        self.bitRate = bitRate
+        self.downmix = downmix
+        self.channelMap = channelMap
+    }
 
     func apply(_ converter: AVAudioConverter?, oldValue: AudioCodecSettings?) {
         guard let converter else {

--- a/Sources/IO/IOAudioMixerSettings.swift
+++ b/Sources/IO/IOAudioMixerSettings.swift
@@ -22,13 +22,13 @@ public struct IOAudioMixerSettings: Sendable {
     public let channels: UInt32
 
     /// Specifies the muted that indicates whether the audio output is muted.
-    public var isMuted = false
+    public var isMuted: Bool
 
     /// Specifies the main track number.
-    public var mainTrack: UInt8 = 0
+    public var mainTrack: UInt8
 
     /// Specifies the track settings.
-    public var tracks: [UInt8: IOAudioMixerTrackSettings] = .init()
+    public var tracks: [UInt8: IOAudioMixerTrackSettings]
 
     /// Specifies the maximum number of channels supported by the system
     /// - Description: The maximum number of channels to be used when the number of channels is 0 (not set). More than 2 channels are not supported by the service. It is defined to prevent audio issues since recording does not support more than 2 channels.
@@ -37,10 +37,16 @@ public struct IOAudioMixerSettings: Sendable {
     /// Creates a new instance of a settings.
     public init(
         sampleRate: Float64 = 0,
-        channels: UInt32 = 0
+        channels: UInt32 = 0,
+        isMuted: Bool = false,
+        mainTrack: UInt8 = 0,
+        tracks: [UInt8: IOAudioMixerTrackSettings] = .init()
     ) {
         self.sampleRate = sampleRate
         self.channels = channels
+        self.isMuted = isMuted
+        self.mainTrack = mainTrack
+        self.tracks = tracks
     }
 
     func invalidateOutputFormat(_ oldValue: Self) -> Bool {

--- a/Sources/IO/IOAudioMixerTrack.swift
+++ b/Sources/IO/IOAudioMixerTrack.swift
@@ -14,7 +14,7 @@ public struct IOAudioMixerTrackSettings: Codable, Sendable {
     public static let `default` = IOAudioMixerTrackSettings()
 
     /// Specifies the volume for output.
-    public var volume: Float = 1.0
+    public var volume: Float
 
     /// Specifies the muted that indicates whether the audio output is muted.
     public var isMuted = false
@@ -29,6 +29,14 @@ public struct IOAudioMixerTrackSettings: Codable, Sendable {
     /// channelMap = [2, 3]
     /// ```
     public var channelMap: [Int]?
+
+    /// Creates a new instance.
+    public init(volume: Float = 1.0, isMuted: Bool = false, downmix: Bool = true, channelMap: [Int]? = nil) {
+        self.volume = volume
+        self.isMuted = isMuted
+        self.downmix = downmix
+        self.channelMap = channelMap
+    }
 
     func apply(_ converter: AVAudioConverter?, oldValue: IOAudioMixerTrackSettings?) {
         guard let converter else {

--- a/Sources/IO/IOVideoMixerSettings.swift
+++ b/Sources/IO/IOVideoMixerSettings.swift
@@ -16,11 +16,18 @@ public struct IOVideoMixerSettings: Codable, Sendable {
     }
 
     /// Specifies the image rendering mode.
-    public var mode: Mode = .passthrough
+    public var mode: Mode
 
     /// Specifies the muted indicies whether freeze video signal or not.
-    public var isMuted = false
+    public var isMuted: Bool
 
     /// Specifies the main track number.
-    public var mainTrack: UInt8 = 0
+    public var mainTrack: UInt8
+
+    /// Create a new instance.
+    public init(mode: Mode = .passthrough, isMuted: Bool = false, mainTrack: UInt8 = 0) {
+        self.mode = mode
+        self.isMuted = isMuted
+        self.mainTrack = mainTrack
+    }
 }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- Implemented it because it can be convenient when specifying everything at once in the constructor.

```swift
let videoMixerSettings = stream.videoMixerSettings

stream.videoMixerSettings = .init(
  mode: videoMixerSettings.mode,
  isMuted: videoMixerSettings.isMuted,
  mainTrack: 1
)

```

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

