### PR TITLE
Add custom screen object to render effects on top of the stream

### DIFF
--- a/Sources/Screen/ScreenObject.swift
+++ b/Sources/Screen/ScreenObject.swift
@@ -300,8 +300,13 @@ public final class VideoTrackScreenObject: ScreenObject, ChromaKeyProcessable {
 }
 
 /// An object that manages effects rendering.
-public final class EffectScreenObject: ScreenObject {
+public final class CIImageScreenObject: ScreenObject {
     private var effects: [VideoEffect] = .init()
+    private var image: CIImage?
+
+    public var hasEffects: Bool {
+        !effects.isEmpty
+    }
 
     /// Registers a video effect.
     public func registerVideoEffect(_ effect: VideoEffect) -> Bool {
@@ -322,10 +327,7 @@ public final class EffectScreenObject: ScreenObject {
     }
 
     override public func makeImage(_ renderer: some ScreenRenderer) -> CGImage? {
-        guard !effects.isEmpty else {
-            return nil
-        }
-        var image = CIImage(color: .clear).cropped(to: renderer.bounds)
+        var image = (image ?? CIImage(color: .clear)).cropped(to: renderer.bounds)
         for effect in effects {
             image = effect.execute(image, info: nil)
         }

--- a/Sources/Screen/ScreenObject.swift
+++ b/Sources/Screen/ScreenObject.swift
@@ -299,6 +299,45 @@ public final class VideoTrackScreenObject: ScreenObject, ChromaKeyProcessable {
     }
 }
 
+/// An object that manages effects rendering.
+public final class EffectScreenObject: ScreenObject {
+    private var effects: [VideoEffect] = .init()
+
+    /// Registers a video effect.
+    public func registerVideoEffect(_ effect: VideoEffect) -> Bool {
+        if effects.contains(where: { $0 === effect }) {
+            return false
+        }
+        effects.append(effect)
+        return true
+    }
+
+    /// Unregisters a video effect.
+    public func unregisterVideoEffect(_ effect: VideoEffect) -> Bool {
+        if let index = effects.firstIndex(where: { $0 === effect }) {
+            effects.remove(at: index)
+            return true
+        }
+        return false
+    }
+
+    override public func makeImage(_ renderer: some ScreenRenderer) -> CGImage? {
+        guard !effects.isEmpty else {
+            return nil
+        }
+        var image = CIImage(color: .clear).cropped(to: renderer.bounds)
+        for effect in effects {
+            image = effect.execute(image, info: nil)
+        }
+        return renderer.context.createCGImage(image, from: image.extent)
+    }
+
+    override func draw(_ renderer: some ScreenRenderer) {
+        super.draw(renderer)
+        invalidateLayout()
+    }
+}
+
 /// An object that manages offscreen rendering a text source.
 public final class TextScreenObject: ScreenObject {
     /// Specifies the text value.

--- a/Sources/Screen/ScreenRenderer.swift
+++ b/Sources/Screen/ScreenRenderer.swift
@@ -124,7 +124,7 @@ final class ScreenRendererByCPU: ScreenRenderer {
 
     func layout(_ screenObject: ScreenObject) {
         autoreleasepool {
-            guard let image = screenObject.makeImage(self) else {
+            guard screenObject.isVisible, let image = screenObject.makeImage(self) else {
                 return
             }
             do {
@@ -149,7 +149,7 @@ final class ScreenRendererByCPU: ScreenRenderer {
     }
 
     func draw(_ screenObject: ScreenObject) {
-        guard var image = images[screenObject] else {
+        guard screenObject.isVisible, var image = images[screenObject] else {
             return
         }
 


### PR DESCRIPTION
## Description & motivation
* Feature: add dedicated video effects screen object

This PR introduces a new screen object that allows to render effects on top of the other screen objects. By default `IOVideoMixer` uses `videoTrackScreenObject` to render effects. As result, multicam covers the effects during the rendering. Having custom object allows to add it as a screen child and display extra elements on top of the stream. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:
<details>
  <summary>Spoiler</summary>

![Screenshot 2024-08-28 at 3 15 06 PM](https://github.com/user-attachments/assets/98ca578b-8888-4a38-9acd-11f40bbaa9f3)

  
</details>

