### PR TITLE
Support SRT listener mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Project name    |Notes       |License
 - [x] Playback(beta)
 - [ ] mode
   - [x] caller
-  - [ ] listener
+  - [x] listener
   - [ ] rendezvous
 
 ### Offscreen Rendering.

--- a/Sources/IO/IOStream.swift
+++ b/Sources/IO/IOStream.swift
@@ -83,6 +83,11 @@ open class IOStream: NSObject {
     /// The lockQueue.
     public let lockQueue: DispatchQueue = .init(label: "com.haishinkit.HaishinKit.IOStream.lock", qos: .userInitiated)
 
+    /// The boolean value that indicates audio samples allow access or not.
+    public internal(set) var audioSampleAccess = true
+    /// The boolean value that indicates video samples allow access or not.
+    public internal(set) var videoSampleAccess = true
+
     /// The offscreen rendering object.
     public var screen: Screen {
         return mixer.videoIO.screen
@@ -560,6 +565,9 @@ extension IOStream: IOTellyUnitDelegate {
     // MARK: IOTellyUnitDelegate
     func tellyUnit(_ tellyUnit: IOTellyUnit, dequeue sampleBuffer: CMSampleBuffer) {
         mixer.videoIO.view?.enqueue(sampleBuffer)
+        if videoSampleAccess {
+            observers.forEach { $0.stream(self, didOutput: sampleBuffer) }
+        }
     }
 
     func tellyUnit(_ tellyUnit: IOTellyUnit, didBufferingChanged: Bool) {

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -171,10 +171,6 @@ open class RTMPStream: IOStream {
     public internal(set) var info = RTMPStreamInfo()
     /// The object encoding (AMF). Framework supports AMF0 only.
     public private(set) var objectEncoding: RTMPObjectEncoding = RTMPConnection.defaultObjectEncoding
-    /// The boolean value that indicates audio samples allow access or not.
-    public private(set) var audioSampleAccess = true
-    /// The boolean value that indicates video samples allow access or not.
-    public private(set) var videoSampleAccess = true
     /// Incoming audio plays on the stream or not.
     public var receiveAudio = true {
         didSet {


### PR DESCRIPTION
## Description & motivation
- Supported SRT Listener mode.
- Only one connection is supported. By configuring as follows, you can wait as a listener to receive and play a stream from another client.

```swift
connection = SRTConnection()

stream = SRTStream(connection: connection)
stream.play()

view.attachStream(stream)
connection.open(URL(string: "srt://0.0.0.0:9998"), mode: .listener)
```

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

