### PR TITLE
Optimize ScreenObject CPU usage.

### DIFF
--- a/Sources/Screen/ScreenObject.swift
+++ b/Sources/Screen/ScreenObject.swift
@@ -35,6 +35,11 @@ open class ScreenObject {
         case bottom
     }
 
+    enum BlendMode {
+        case normal
+        case alpha
+    }
+
     /// The screen object container that contains this screen object
     public internal(set) weak var parent: ScreenObjectContainer?
 
@@ -70,6 +75,10 @@ open class ScreenObject {
 
     /// Specifies the alignment position along the horizontal axis.
     public var horizontalAlignment: HorizontalAlignment = .left
+
+    var blendMode: BlendMode {
+        .alpha
+    }
 
     var shouldInvalidateLayout = true
 
@@ -218,6 +227,13 @@ public final class VideoTrackScreenObject: ScreenObject, ChromaKeyProcessable {
             }
             invalidateLayout()
         }
+    }
+
+    override var blendMode: ScreenObject.BlendMode {
+        if 0.0 < cornerRadius || chromaKeyColor != nil {
+            return .alpha
+        }
+        return .normal
     }
 
     private var queue: TypedBlockQueue<CMSampleBuffer>?

--- a/Sources/Screen/ScreenRenderer.swift
+++ b/Sources/Screen/ScreenRenderer.swift
@@ -21,6 +21,7 @@ public protocol ScreenRenderer: AnyObject {
 
 final class ScreenRendererByCPU: ScreenRenderer {
     static let noFlags = vImage_Flags(kvImageNoFlags)
+    static let doNotTile = vImage_Flags(kvImageDoNotTile)
 
     var bounds: CGRect = .init(origin: .zero, size: Screen.size)
 
@@ -165,12 +166,22 @@ final class ScreenRendererByCPU: ScreenRenderer {
 
         switch pixelFormatType {
         case kCVPixelFormatType_32ARGB:
-            vImageAlphaBlend_ARGB8888(
-                &image,
-                &destination,
-                &destination,
-                vImage_Flags(kvImageDoNotTile)
-            )
+            switch screenObject.blendMode {
+            case .normal:
+                vImageCopyBuffer(
+                    &image,
+                    &destination,
+                    4,
+                    Self.doNotTile
+                )
+            case .alpha:
+                vImageAlphaBlend_ARGB8888(
+                    &image,
+                    &destination,
+                    &destination,
+                    Self.doNotTile
+                )
+            }
         default:
             break
         }

--- a/Sources/Screen/StreamScreenObject.swift
+++ b/Sources/Screen/StreamScreenObject.swift
@@ -29,6 +29,13 @@ public final class StreamScreenObject: ScreenObject, ChromaKeyProcessable {
         }
     }
 
+    override var blendMode: ScreenObject.BlendMode {
+        if 0.0 < cornerRadius || chromaKeyColor != nil {
+            return .alpha
+        }
+        return .normal
+    }
+
     override public func makeBounds(_ size: CGSize) -> CGRect {
         guard parent != nil, let image = sampleBuffer?.formatDescription?.dimensions.size else {
             return super.makeBounds(size)


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- I have optimized the CPU usage.
  - I've set it to use vImageCopy when alpha rendering is not needed, to avoid unnecessary computations.

**Before**
`iPhone 16 Pro max: 40-50%`

**After**
`iPhone 16 Pro max: 35-45%`

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

