### PR TITLE
Optimize MTHKView.swift

### DIFF
--- a/Sources/Extension/CVPixelBuffer+Extension.swift
+++ b/Sources/Extension/CVPixelBuffer+Extension.swift
@@ -1,4 +1,5 @@
 import Accelerate
+import CoreImage
 import CoreVideo
 import Foundation
 
@@ -108,6 +109,10 @@ extension CVPixelBuffer {
             CVPixelBufferUnlockBaseAddress(self, lockFlags)
         }
         try lambda(self)
+    }
+
+    func makeCIImage() -> CIImage {
+        CIImage(cvPixelBuffer: self)
     }
 
     @inlinable


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- I optimized the rendering of MTHKView. In the WWDC session, context.startTask was recommended for rendering, so I replaced it accordingly.
  - https://developer.apple.com/videos/play/wwdc2020/10008

**Before**
`iPhone 16 Pro max: 35-45%`

**After**
`iPhone 16 Pro max: 30-35%`
 - There is some fluctuation every time it's transferred to the actual device, but since it's stabilizing around 30-35

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

