### PR TITLE
fix: handling existing file when starting recording

### DIFF
--- a/Sources/HKStream/HKStreamRecorder.swift
+++ b/Sources/HKStream/HKStreamRecorder.swift
@@ -123,6 +123,9 @@ public actor HKStreamRecorder {
         audioPresentationTime = .zero
 
         let url = moviesDirectory.appendingPathComponent(fileName).appendingPathExtension("mp4")
+        if FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.removeItem(at: url)
+        }
         writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
         isRecording = true
     }


### PR DESCRIPTION
## Description & motivation

This PR introduces a fix to prevent potential errors when starting a new recording with HKStreamRecorder. Previously, attempting to record with a file name that already existed in the destination directory would cause an error, as AVAssetWriter fails if a file already exists at the specified path. This fix ensures that any existing file with the specified name is removed before the recording process begins.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
## Screenshots:

