### PR TITLE
Fix: build issue where mac catalyst target had AVCaptureSession extension redeclaration

### DIFF
--- a/Sources/Extension/AVCaptureSession+Extension.swift
+++ b/Sources/Extension/AVCaptureSession+Extension.swift
@@ -17,7 +17,7 @@ extension AVCaptureSession {
         }
     }
 }
-#endif
+#else
 
 @available(tvOS 17.0, *)
 extension AVCaptureSession {
@@ -36,4 +36,5 @@ extension AVCaptureSession {
         }
     }
 }
+#endif
 // swiftlint:enable unused_setter_value

--- a/Sources/Mixer/AudioMixerByMultiTrack.swift
+++ b/Sources/Mixer/AudioMixerByMultiTrack.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import CoreAudio
 
 final class AudioMixerByMultiTrack: AudioMixer {
     private static let defaultSampleTime: AVAudioFramePosition = 0

--- a/Sources/Mixer/AudioMonitor.swift
+++ b/Sources/Mixer/AudioMonitor.swift
@@ -2,6 +2,7 @@ import AudioUnit
 import AVFoundation
 import CoreMedia
 import Foundation
+import CoreAudio
 
 final class AudioMonitor {
     var inputFormat: AVAudioFormat? {

--- a/Sources/Mixer/AudioRingBuffer.swift
+++ b/Sources/Mixer/AudioRingBuffer.swift
@@ -2,6 +2,7 @@ import Accelerate
 import AVFoundation
 import CoreMedia
 import Foundation
+import CoreAudio
 
 final class AudioRingBuffer {
     private static let bufferCounts: UInt32 = 16

--- a/Sources/RTMP/RTMPStream.swift
+++ b/Sources/RTMP/RTMPStream.swift
@@ -7,7 +7,7 @@ import UIKit
 typealias View = UIView
 #endif
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 typealias View = NSView
 #endif

--- a/Sources/Screen/Shape.swift
+++ b/Sources/Screen/Shape.swift
@@ -26,7 +26,7 @@ final class RoundedSquareShape: Shape {
             return nil
         }
         let path = CGPath(roundedRect: rect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
-        #if canImport(AppKit)
+        #if canImport(AppKit) && !targetEnvironment(macCatalyst)
         context.setFillColor(NSColor.white.cgColor)
         #endif
         #if canImport(UIKit)


### PR DESCRIPTION
AVCaptureSession extension was redeclared if targetEnvironment(macCatalyst) was used

## Description & motivation

Modified AVCaptureSession extension to separate  targetEnvironment(macCatalyst) and rest of the extension

## Type of change
Please delete options that are not relevant.
- [ x] Bug fix (non-breaking change which fixes an issue)
