### PR TITLE
Ingest Support the OPUS format for Enhanced RTMP.

### DIFF
--- a/HaishinKit/Sources/Codec/AudioCodec.swift
+++ b/HaishinKit/Sources/Codec/AudioCodec.swift
@@ -6,7 +6,7 @@ import AVFoundation
  * - seealso: https://developer.apple.com/library/ios/technotes/tn2236/_index.html
  */
 final class AudioCodec {
-    static let frameCamacity: UInt32 = 1024
+    static let defaultInputBuffersCursor = 0
 
     /// Specifies the settings for audio codec.
     var settings: AudioCodecSettings = .default {
@@ -32,8 +32,8 @@ final class AudioCodec {
             guard inputFormat != oldValue else {
                 return
             }
-            cursor = 0
             inputBuffers.removeAll()
+            inputBuffersCursor = Self.defaultInputBuffersCursor
             outputBuffers.removeAll()
             audioConverter = makeAudioConverter()
             for _ in 0..<settings.format.inputBufferCounts {
@@ -43,7 +43,8 @@ final class AudioCodec {
             }
         }
     }
-    private var cursor: Int = 0
+    private var audioTime = AudioTime()
+    private var ringBuffer: AudioRingBuffer?
     private var inputBuffers: [AVAudioBuffer] = []
     private var continuation: AsyncStream<(AVAudioBuffer, AVAudioTime)>.Continuation? {
         didSet {
@@ -52,6 +53,7 @@ final class AudioCodec {
     }
     private var outputBuffers: [AVAudioBuffer] = []
     private var audioConverter: AVAudioConverter?
+    private var inputBuffersCursor = AudioCodec.defaultInputBuffersCursor
 
     func append(_ sampleBuffer: CMSampleBuffer) {
         guard isRunning else {
@@ -91,33 +93,52 @@ final class AudioCodec {
             return
         }
         var error: NSError?
-        let outputBuffer = self.outputBuffer
-        let outputStatus = audioConverter.convert(to: outputBuffer, error: &error) { _, inputStatus in
-            switch self.inputBuffer {
-            case let inputBuffer as AVAudioCompressedBuffer:
-                inputBuffer.copy(audioBuffer)
-            case let inputBuffer as AVAudioPCMBuffer:
-                if !inputBuffer.copy(audioBuffer) {
-                    inputBuffer.muted(true)
+        if let audioBuffer = audioBuffer as? AVAudioPCMBuffer {
+            ringBuffer?.append(audioBuffer, when: when)
+            if !audioTime.hasAnchor {
+                audioTime.anchor(when)
+            }
+        }
+        var outputStatus: AVAudioConverterOutputStatus = .endOfStream
+        repeat {
+            let outputBuffer = self.outputBuffer
+            outputStatus = audioConverter.convert(to: outputBuffer, error: &error) { inNumberFrames, inputStatus in
+                switch self.inputBuffer {
+                case let inputBuffer as AVAudioCompressedBuffer:
+                    inputBuffer.copy(audioBuffer)
+                    inputStatus.pointee = .haveData
+                    return inputBuffer
+                case let inputBuffer as AVAudioPCMBuffer:
+                    if inNumberFrames <= (self.ringBuffer?.counts ?? 0) {
+                        _ = self.ringBuffer?.render(inNumberFrames, ioData: inputBuffer.mutableAudioBufferList)
+                        inputBuffer.frameLength = inNumberFrames
+                        inputStatus.pointee = .haveData
+                        self.audioTime.advanced(AVAudioFramePosition(inNumberFrames))
+                        return self.inputBuffer
+                    } else {
+                        inputStatus.pointee = .noDataNow
+                        return nil
+                    }
+                default:
+                    inputStatus.pointee = .noDataNow
+                    return nil
+                }
+            }
+            switch outputStatus {
+            case .haveData:
+                if audioTime.hasAnchor {
+                    continuation?.yield((outputBuffer, audioTime.at))
+                } else {
+                    continuation?.yield((outputBuffer, when))
+                }
+                inputBuffersCursor += 1
+                if inputBuffersCursor == inputBuffers.count {
+                    inputBuffersCursor = Self.defaultInputBuffersCursor
                 }
             default:
-                break
+                releaseOutputBuffer(outputBuffer)
             }
-            inputStatus.pointee = .haveData
-            return self.inputBuffer
-        }
-        switch outputStatus {
-        case .haveData:
-            continuation?.yield((outputBuffer, when))
-        case .error:
-            break
-        default:
-            break
-        }
-        cursor += 1
-        if cursor == inputBuffers.count {
-            cursor = 0
-        }
+        } while(outputStatus == .haveData && settings.format != .pcm)
     }
 
     private func makeInputBuffer() -> AVAudioBuffer? {
@@ -126,8 +147,9 @@ final class AudioCodec {
         }
         switch inputFormat.formatDescription.mediaSubType {
         case .linearPCM:
-            let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: Self.frameCamacity)
-            buffer?.frameLength = Self.frameCamacity
+            let frameCapacity = settings.format.makeFramesPerPacket(inputFormat.sampleRate)
+            let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: frameCapacity)
+            buffer?.frameLength = frameCapacity
             return buffer
         default:
             return AVAudioCompressedBuffer(format: inputFormat, packetCapacity: 1, maximumPacketSize: 1024)
@@ -145,6 +167,9 @@ final class AudioCodec {
         }
         let converter = AVAudioConverter(from: inputFormat, to: outputFormat)
         settings.apply(converter, oldValue: nil)
+        if inputFormat.formatDescription.mediaSubType == .linearPCM {
+            ringBuffer = AudioRingBuffer(inputFormat)
+        }
         return converter
     }
 }
@@ -170,7 +195,7 @@ extension AudioCodec: Codec {
     }
 
     private var inputBuffer: AVAudioBuffer {
-        return inputBuffers[cursor]
+        return inputBuffers[inputBuffersCursor]
     }
 }
 
@@ -180,6 +205,7 @@ extension AudioCodec: Runner {
         guard !isRunning else {
             return
         }
+        audioTime.reset()
         audioConverter?.reset()
         isRunning = true
     }
@@ -190,5 +216,6 @@ extension AudioCodec: Runner {
         }
         isRunning = false
         continuation = nil
+        ringBuffer = nil
     }
 }

--- a/HaishinKit/Sources/Codec/OpusHeaderPacket.swift
+++ b/HaishinKit/Sources/Codec/OpusHeaderPacket.swift
@@ -1,0 +1,30 @@
+import CoreMedia
+import Foundation
+
+struct OpusHeaderPacket {
+    static let signature = "OpusHead"
+
+    let channels: Int
+    let sampleRate: Double
+
+    var payload: Data {
+        var data = Data()
+        data.append(contentsOf: Self.signature.utf8)
+        data.append(0x01)
+        data.append(UInt8(channels))
+        data.append(UInt16(0).data)
+        data.append(UInt32(sampleRate).data)
+        data.append(UInt16(0).data)
+        data.append(0x00)
+        return data
+    }
+
+    init?(formatDescription: CMFormatDescription?) {
+        guard
+            let streamDescription = formatDescription?.audioStreamBasicDescription else {
+            return nil
+        }
+        channels = Int(streamDescription.mChannelsPerFrame)
+        sampleRate = streamDescription.mSampleRate
+    }
+}

--- a/HaishinKit/Sources/RTMP/RTMPConnection.swift
+++ b/HaishinKit/Sources/RTMP/RTMPConnection.swift
@@ -34,8 +34,8 @@ public actor RTMPConnection: NetworkConnection {
     public static let defaultWindowSizeS: Int64 = 250000
     /// The supported protocols are rtmp, rtmps, rtmpt and rtmps.
     public static let supportedProtocols: Set<String> = ["rtmp", "rtmps"]
-    /// The supported fourCcList are hvc1.
-    public static let supportedFourCcList = ["hvc1"]
+    /// The supported fourCcList.
+    public static let supportedFourCcList = [RTMPVideoFourCC.hevc.description, RTMPAudioFourCC.opus.description]
     /// The default RTMP port is 1935.
     public static let defaultPort: Int = 1935
     /// The default RTMPS port is 443.
@@ -50,6 +50,14 @@ public actor RTMPConnection: NetworkConnection {
     public static let defaultObjectEncoding: RTMPObjectEncoding = .amf0
     /// The default an rtmp request time out value (ms).
     public static let defaultRequestTimeout: UInt64 = 3000
+
+    static let videoFourCcInfoMap: AMFObject = [
+        RTMPVideoFourCC.hevc.description: FourCcInfoMask.canDecode.rawValue | FourCcInfoMask.canEncode.rawValue
+    ]
+
+    static let audioFourCcInfoMap: AMFObject = [
+        RTMPAudioFourCC.opus.description: FourCcInfoMask.canEncode.rawValue
+    ]
 
     private static let connectTransactionId = 1
 
@@ -132,6 +140,19 @@ public actor RTMPConnection: NetworkConnection {
 
     enum VideoFunction: UInt8 {
         case clientSeek = 1
+    }
+
+    enum FourCcInfoMask: Int {
+        case canDecode = 0x01
+        case canEncode = 0x02
+        case canForward = 0x04
+    }
+
+    enum CapsEx: Int {
+        case recoonect = 0x01
+        case multitrack = 0x02
+        case modEx = 0x04
+        case timestampNanoOffset = 0x08
     }
 
     /// The URL of .swf.

--- a/HaishinKit/Sources/RTMP/RTMPEnhanced.swift
+++ b/HaishinKit/Sources/RTMP/RTMPEnhanced.swift
@@ -1,7 +1,77 @@
+enum RTMPAudioFourCC: UInt32 {
+    case ac3 = 0x61632D33 // ac-3
+    case eac3 = 0x65632D33  // ec-3
+    case opus = 0x4F707573 // Opus
+    case mp3 = 0x2E6D7033 // .mp3
+    case flac = 0x664C6143 // fLaC
+    case aac = 0x6D703461 // mp4a
+
+    var isSupported: Bool {
+        switch self {
+        case .ac3:
+            return false
+        case .eac3:
+            return false
+        case .opus:
+            return true
+        case .mp3:
+            return false
+        case .flac:
+            return false
+        case .aac:
+            return false
+        }
+    }
+}
+
+extension RTMPAudioFourCC: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .ac3:
+            return "ac-3"
+        case .eac3:
+            return "ex-3"
+        case .opus:
+            return "Opus"
+        case .mp3:
+            return ".mp3"
+        case .flac:
+            return "fLaC"
+        case .aac:
+            return "mp4a"
+        }
+    }
+}
+
+enum RTMPAudioPacketType: UInt8 {
+    case sequenceStart = 0
+    case codedFrames = 1
+    case sequenceEnd = 2
+    case multiChannelConfig = 4
+    case multiTrack = 5
+    case modEx = 7
+}
+
+enum RTMPAudioPacketModExType: Int {
+    case timestampOffsetNano = 0
+}
+
+enum RTMPAVMultiTrackType: Int {
+    case oneTrack = 0
+    case manyTracks = 1
+    case manyTracksManyCOdecs = 2
+}
+
+enum RTMPAudioChannelOrder: Int {
+    case unspecified = 0
+    case native = 1
+    case custom = 2
+}
+
 enum RTMPVideoFourCC: UInt32 {
-    case av1 = 0x61763031 // { 'a', 'v', '0', '1' }
-    case vp9 = 0x76703039 // { 'v', 'p', '0', '9' }
-    case hevc = 0x68766331 // { 'h', 'v', 'c', '1' }
+    case av1 = 0x61763031 // av01
+    case vp9 = 0x76703039 // vp09
+    case hevc = 0x68766331 // hvc1
 
     var isSupported: Bool {
         switch self {
@@ -11,6 +81,19 @@ enum RTMPVideoFourCC: UInt32 {
             return false
         case .hevc:
             return true
+        }
+    }
+}
+
+extension RTMPVideoFourCC: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .av1:
+            return "av01"
+        case .vp9:
+            return "vp09"
+        case .hevc:
+            return "hvc1"
         }
     }
 }

--- a/HaishinKit/Sources/RTMP/RTMPFoundation.swift
+++ b/HaishinKit/Sources/RTMP/RTMPFoundation.swift
@@ -38,7 +38,7 @@ enum RTMPAudioCodec: UInt8 {
     case g711A = 7
     /// The G.711 mu-law codec.
     case g711MU = 8
-    /// The signal FOURCC mode.
+    /// The signal FOURCC mode. E-RTMP.
     case exheader = 9
     /// The AAC codec.
     case aac = 10

--- a/HaishinKit/Sources/RTMP/RTMPMessage.swift
+++ b/HaishinKit/Sources/RTMP/RTMPMessage.swift
@@ -387,14 +387,25 @@ struct RTMPAudioMessage: RTMPMessage {
     }
 
     init?(streamId: UInt32, timestamp: UInt32, formatDescription: CMFormatDescription?) {
-        guard let config = AudioSpecificConfig(formatDescription: formatDescription) else {
-            return nil
-        }
         self.streamId = streamId
         self.timestamp = timestamp
-        var buffer = Data([Self.AAC_HEADER, RTMPAACPacketType.seq.rawValue])
-        buffer.append(contentsOf: config.bytes)
-        self.payload = buffer
+        switch formatDescription?.mediaSubType {
+        case .opus:
+            guard let header = OpusHeaderPacket(formatDescription: formatDescription) else {
+                return nil
+            }
+            var buffer = Data([RTMPAudioCodec.exheader.rawValue << 4 | RTMPAudioPacketType.sequenceStart.rawValue])
+            buffer.append(contentsOf: RTMPAudioFourCC.opus.rawValue.bigEndian.data)
+            buffer.append(header.payload)
+            self.payload = buffer
+        default:
+            guard let config = AudioSpecificConfig(formatDescription: formatDescription) else {
+                return nil
+            }
+            var buffer = Data([Self.AAC_HEADER, RTMPAACPacketType.seq.rawValue])
+            buffer.append(contentsOf: config.bytes)
+            self.payload = buffer
+        }
     }
 
     init?(streamId: UInt32, timestamp: UInt32, audioBuffer: AVAudioCompressedBuffer?) {
@@ -403,9 +414,17 @@ struct RTMPAudioMessage: RTMPMessage {
         }
         self.streamId = streamId
         self.timestamp = timestamp
-        var buffer = Data([Self.AAC_HEADER, RTMPAACPacketType.raw.rawValue])
-        buffer.append(audioBuffer.data.assumingMemoryBound(to: UInt8.self), count: Int(audioBuffer.byteLength))
-        self.payload = buffer
+        switch audioBuffer.format.formatDescription.mediaSubType {
+        case .opus:
+            var buffer = Data([RTMPAudioCodec.exheader.rawValue << 4 | RTMPAudioPacketType.codedFrames.rawValue])
+            buffer.append(contentsOf: RTMPAudioFourCC.opus.rawValue.bigEndian.data)
+            buffer.append(audioBuffer.data.assumingMemoryBound(to: UInt8.self), count: Int(audioBuffer.byteLength))
+            self.payload = buffer
+        default:
+            var buffer = Data([Self.AAC_HEADER, RTMPAACPacketType.raw.rawValue])
+            buffer.append(audioBuffer.data.assumingMemoryBound(to: UInt8.self), count: Int(audioBuffer.byteLength))
+            self.payload = buffer
+        }
     }
 
     func copyMemory(_ audioBuffer: AVAudioCompressedBuffer?) {

--- a/HaishinKit/Tests/RTMP/RTMPVideoFourCCTests.swift
+++ b/HaishinKit/Tests/RTMP/RTMPVideoFourCCTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import HaishinKit
 
-@Suite struct FLVVideoFourCCTests {
+@Suite struct RTMPVideoFourCCTests {
     @Test func main() {
         #expect("av01" == str4(n: Int(RTMPVideoFourCC.av1.rawValue)))
         #expect("hvc1" == str4(n: Int(RTMPVideoFourCC.hevc.rawValue)))


### PR DESCRIPTION
## Description & motivation
Support for the OPUS extension in Enhanced RTMP.  This PR is for Ingest only. I’d like to implement Playback as well, but I can’t find a product with server-side support. Could someone help?

## Usage
```swift
var audioSettings = AudioCodecSettings()
audioSettings.format = .opus
await stream.setAudioSettings(audioSettings)
```

- I tests using mediamtx.
  - Ingest H264 + Opus
  - There seems to be some audio dropouts, but it's unclear whether the issue lies with HaishinKit or some other factor.
```
ffplay http://localhost:8888/live/live/index.m3u8
```

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

