### PR TITLE
allow changing the sampleRate for each stream.

### DIFF
--- a/HaishinKit/Sources/Codec/AudioCodecSettings.swift
+++ b/HaishinKit/Sources/Codec/AudioCodecSettings.swift
@@ -1,7 +1,7 @@
 import AVFAudio
 import Foundation
 
-/// Constraints on the audio codec  compression settings.
+/// Constraints on the audio codec compression settings.
 public struct AudioCodecSettings: Codable, Sendable {
     /// The default value.
     public static let `default` = AudioCodecSettings()
@@ -109,6 +109,23 @@ public struct AudioCodecSettings: Codable, Sendable {
             }
         }
 
+        var supportedSampleRate: [Float64]? {
+            switch self {
+            case .opus:
+                return [8000.0, 12000.0, 16000.0, 24000.0, 48000.0]
+            default:
+                return nil
+            }
+        }
+
+        func makeSampleRate(_ input: Float64, output: Float64) -> Float64 {
+            let sampleRate = output == 0 ? input : output
+            guard let supportedSampleRate else {
+                return sampleRate
+            }
+            return supportedSampleRate.sorted { pow($0 - sampleRate, 2) < pow($1 - sampleRate, 2) }.first ?? sampleRate
+        }
+
         func makeFramesPerPacket(_ sampleRate: Double) -> UInt32 {
             switch self {
             case .aac:
@@ -133,14 +150,15 @@ public struct AudioCodecSettings: Codable, Sendable {
             }
         }
 
-        func makeOutputAudioFormat(_ format: AVAudioFormat) -> AVAudioFormat? {
+        func makeOutputAudioFormat(_ format: AVAudioFormat, sampleRate: Float64) -> AVAudioFormat? {
+            let mSampleRate = makeSampleRate(format.sampleRate, output: sampleRate)
             let config = AudioSpecificConfig.ChannelConfiguration(channelCount: format.channelCount)
             var streamDescription = AudioStreamBasicDescription(
-                mSampleRate: format.sampleRate,
+                mSampleRate: mSampleRate,
                 mFormatID: formatID,
                 mFormatFlags: formatFlags,
                 mBytesPerPacket: bytesPerPacket,
-                mFramesPerPacket: makeFramesPerPacket(format.sampleRate),
+                mFramesPerPacket: makeFramesPerPacket(mSampleRate),
                 mBytesPerFrame: bytesPerFrame,
                 mChannelsPerFrame: min(
                     config?.channelCount ?? format.channelCount,
@@ -165,6 +183,9 @@ public struct AudioCodecSettings: Codable, Sendable {
     /// Specifies the map of the output to input channels.
     public var channelMap: [Int]?
 
+    /// Specifies the sampleRate of audio output. A value of 0 will be the same as the main track source.
+    public let sampleRate: Float64
+
     /// Specifies the output format.
     public var format: AudioCodecSettings.Format = .aac
 
@@ -173,11 +194,13 @@ public struct AudioCodecSettings: Codable, Sendable {
         bitRate: Int = AudioCodecSettings.defaultBitRate,
         downmix: Bool = true,
         channelMap: [Int]? = nil,
+        sampleRate: Float64 = 0,
         format: AudioCodecSettings.Format = .aac
     ) {
         self.bitRate = bitRate
         self.downmix = downmix
         self.channelMap = channelMap
+        self.sampleRate = sampleRate
         self.format = format
     }
 

--- a/HaishinKit/Sources/Mixer/AudioRingBuffer.swift
+++ b/HaishinKit/Sources/Mixer/AudioRingBuffer.swift
@@ -37,6 +37,10 @@ final class AudioRingBuffer {
         self.outputBuffer.frameLength = self.outputBuffer.frameCapacity
     }
 
+    func isDataAvailable(_ inNumberFrames: UInt32) -> Bool {
+        return inNumberFrames <= counts
+    }
+
     func append(_ sampleBuffer: CMSampleBuffer) {
         guard CMSampleBufferDataIsReady(sampleBuffer) else {
             return

--- a/HaishinKit/Sources/RTMP/RTMPEnhanced.swift
+++ b/HaishinKit/Sources/RTMP/RTMPEnhanced.swift
@@ -1,10 +1,27 @@
-enum RTMPAudioFourCC: UInt32 {
+enum RTMPAudioFourCC: UInt32, CustomStringConvertible {
     case ac3 = 0x61632D33 // ac-3
     case eac3 = 0x65632D33  // ec-3
     case opus = 0x4F707573 // Opus
     case mp3 = 0x2E6D7033 // .mp3
     case flac = 0x664C6143 // fLaC
     case aac = 0x6D703461 // mp4a
+
+    var description: String {
+        switch self {
+        case .ac3:
+            return "ac-3"
+        case .eac3:
+            return "ex-3"
+        case .opus:
+            return "Opus"
+        case .mp3:
+            return ".mp3"
+        case .flac:
+            return "fLaC"
+        case .aac:
+            return "mp4a"
+        }
+    }
 
     var isSupported: Bool {
         switch self {
@@ -20,25 +37,6 @@ enum RTMPAudioFourCC: UInt32 {
             return false
         case .aac:
             return false
-        }
-    }
-}
-
-extension RTMPAudioFourCC: CustomStringConvertible {
-    var description: String {
-        switch self {
-        case .ac3:
-            return "ac-3"
-        case .eac3:
-            return "ex-3"
-        case .opus:
-            return "Opus"
-        case .mp3:
-            return ".mp3"
-        case .flac:
-            return "fLaC"
-        case .aac:
-            return "mp4a"
         }
     }
 }
@@ -68,10 +66,21 @@ enum RTMPAudioChannelOrder: Int {
     case custom = 2
 }
 
-enum RTMPVideoFourCC: UInt32 {
+enum RTMPVideoFourCC: UInt32, CustomStringConvertible {
     case av1 = 0x61763031 // av01
     case vp9 = 0x76703039 // vp09
     case hevc = 0x68766331 // hvc1
+
+    var description: String {
+        switch self {
+        case .av1:
+            return "av01"
+        case .vp9:
+            return "vp09"
+        case .hevc:
+            return "hvc1"
+        }
+    }
 
     var isSupported: Bool {
         switch self {
@@ -85,19 +94,6 @@ enum RTMPVideoFourCC: UInt32 {
     }
 }
 
-extension RTMPVideoFourCC: CustomStringConvertible {
-    var description: String {
-        switch self {
-        case .av1:
-            return "av01"
-        case .vp9:
-            return "vp09"
-        case .hevc:
-            return "hvc1"
-        }
-    }
-}
-
 enum RTMPVideoPacketType: UInt8 {
     case sequenceStart = 0
     case codedFrames = 1
@@ -105,4 +101,28 @@ enum RTMPVideoPacketType: UInt8 {
     case codedFramesX = 3
     case metadata = 4
     case mpeg2TSSequenceStart = 5
+}
+
+extension AudioCodecSettings.Format {
+    var codecid: Int {
+        switch self {
+        case .aac:
+            return Int(RTMPAudioCodec.aac.rawValue)
+        case .opus:
+            return Int(RTMPAudioFourCC.opus.rawValue)
+        case .pcm:
+            return Int(RTMPAudioCodec.pcm.rawValue)
+        }
+    }
+}
+
+extension VideoCodecSettings.Format {
+    var codecid: Int {
+        switch self {
+        case .h264:
+            return Int(RTMPVideoCodec.avc.rawValue)
+        case .hevc:
+            return Int(RTMPVideoFourCC.hevc.rawValue)
+        }
+    }
 }

--- a/HaishinKit/Sources/RTMP/RTMPStream.swift
+++ b/HaishinKit/Sources/RTMP/RTMPStream.swift
@@ -682,21 +682,16 @@ public actor RTMPStream {
         if outgoing.videoInputFormat != nil {
             metadata["width"] = outgoing.videoSettings.videoSize.width
             metadata["height"] = outgoing.videoSettings.videoSize.height
-            #if os(iOS) || os(macOS) || os(tvOS)
-            // metadata["framerate"] = stream.frameRate
-            #endif
-            switch outgoing.videoSettings.format {
-            case .h264:
-                metadata["videocodecid"] = RTMPVideoCodec.avc.rawValue
-            case .hevc:
-                metadata["videocodecid"] = RTMPVideoFourCC.hevc.rawValue
-            }
+            metadata["videocodecid"] = outgoing.videoSettings.format.codecid
             metadata["videodatarate"] = outgoing.videoSettings.bitRate / 1000
         }
         if let audioFormat = outgoing.audioInputFormat?.audioStreamBasicDescription {
-            metadata["audiocodecid"] = RTMPAudioCodec.aac.rawValue
+            metadata["audiocodecid"] = outgoing.audioSettings.format.codecid
             metadata["audiodatarate"] = outgoing.audioSettings.bitRate / 1000
-            metadata["audiosamplerate"] = audioFormat.mSampleRate
+            metadata["audiosamplerate"] = outgoing.audioSettings.format.makeSampleRate(
+                audioFormat.mSampleRate,
+                output: outgoing.audioSettings.sampleRate
+            )
         }
         return AMFArray(metadata)
     }

--- a/HaishinKit/Tests/Codec/AudioCodecSettingsFormatTests.swift
+++ b/HaishinKit/Tests/Codec/AudioCodecSettingsFormatTests.swift
@@ -1,0 +1,20 @@
+import AVFoundation
+import Foundation
+import Testing
+
+@testable import HaishinKit
+
+@Suite struct AudioCodecSettingsFormatTests {
+    @Test func opusSampleRate() {
+        #expect(AudioCodecSettings.Format.opus.makeSampleRate(49000, output: 0) == 48000.0)
+        #expect(AudioCodecSettings.Format.opus.makeSampleRate(44100, output: 0) == 48000.0)
+        #expect(AudioCodecSettings.Format.opus.makeSampleRate(20000, output: 0) == 16000.0)
+        #expect(AudioCodecSettings.Format.opus.makeSampleRate(1000, output: 0) == 8000.0)
+    }
+
+    @Test func aacSampleRate() {
+        #expect(AudioCodecSettings.Format.aac.makeSampleRate(48000, output: 44100) == 44100.0)
+        #expect(AudioCodecSettings.Format.aac.makeSampleRate(44100, output: 0) == 44100.0)
+        #expect(AudioCodecSettings.Format.aac.makeSampleRate(20000, output: 0) == 20000.0)
+    }
+}


### PR DESCRIPTION
## Description & motivation
OPUS support has been added here.
- https://github.com/shogo4405/HaishinKit.swift/pull/1674

Since OPUS has fixed supported sample rates, it is more convenient to allow changing the sampling rate per stream, so this modification was made.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:

