### PR TITLE
fixed Large PES packets could be dropped.

### DIFF
--- a/HaishinKit/Sources/ISO/PacketizedElementaryStream.swift
+++ b/HaishinKit/Sources/ISO/PacketizedElementaryStream.swift
@@ -244,7 +244,8 @@ struct PacketizedElementaryStream: PESPacketHeader {
         if length < Int(UInt16.max) {
             packetLength = UInt16(length)
         } else {
-            return nil
+            // any length. https://en.wikipedia.org/wiki/Packetized_elementary_stream
+            packetLength = 0
         }
     }
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
fixed an issue where packets could be dropped when the PES size was large.
- refs https://github.com/shogo4405/HaishinKit.swift/issues/1677

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

