### PR TITLE
Fix crash resetting the RTMP ChunkSize.

### DIFF
--- a/HaishinKit/Sources/RTMP/RTMPChunk.swift
+++ b/HaishinKit/Sources/RTMP/RTMPChunk.swift
@@ -132,7 +132,9 @@ final class RTMPChunkBuffer {
                 return
             }
             let length = chunkSize - data.count
-            data += Data(count: length + Self.headerSize)
+            if 0 < length {
+                data += Data(count: length + Self.headerSize)
+            }
         }
     }
 

--- a/HaishinKit/Tests/RTMP/RTMPChunkBufferTests.swift
+++ b/HaishinKit/Tests/RTMP/RTMPChunkBufferTests.swift
@@ -89,6 +89,13 @@ import Testing
         }
     }
 
+    @Test func chunkSize() {
+        let buffer = RTMPChunkBuffer()
+        buffer.chunkSize = 8192
+        buffer.chunkSize = 128
+        buffer.chunkSize = 8192
+    }
+
     @Test func write() {
         let buffer = RTMPChunkBuffer()
         let connection = RTMPCommandMessage(


### PR DESCRIPTION
## Description & motivation
- fixed an issue where resetting the RTMP ChunkSize would cause a crash.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Reproduce
1. Call rtmpStream#play.
2. Stop
3. Call rtmpStream#play.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

