### PR TITLE
Stereo recording feature for Example iOS ver 2025

### DIFF
--- a/Examples/iOS/AudioSourceService.swift
+++ b/Examples/iOS/AudioSourceService.swift
@@ -1,0 +1,128 @@
+@preconcurrency import AVFoundation
+import Combine
+
+struct AudioSource: Sendable, Hashable, Equatable, CustomStringConvertible {
+    static let empty = AudioSource(portName: "", dataSourceName: "", isSupportedStereo: false)
+
+    let portName: String
+    let dataSourceName: String
+    let isSupportedStereo: Bool
+
+    var description: String {
+        if isSupportedStereo {
+            return "\(portName)(\(dataSourceName))(Stereo)"
+        }
+        return "\(portName)(\(dataSourceName))(Mono)"
+    }
+}
+
+actor AudioSourceService {
+    enum Error: Swift.Error {
+        case missingDataSource(_ source: AudioSource)
+    }
+
+    private(set) var sources: [AudioSource] = [] {
+        didSet {
+            guard sources != oldValue else {
+                return
+            }
+            continuation?.yield(sources)
+        }
+    }
+    private let session = AVAudioSession.sharedInstance()
+    private var continuation: AsyncStream<[AudioSource]>.Continuation? {
+        didSet {
+            oldValue?.finish()
+        }
+    }
+
+    init() {
+        Task { await _init() }
+    }
+
+    private func _init() async {
+        sources = makeAudioSources()
+        Task {
+            for await _ in NotificationCenter.default.notifications(named: AVAudioSession.routeChangeNotification)
+                .compactMap({ $0.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt })
+                .compactMap({ AVAudioSession.RouteChangeReason(rawValue: $0) }) {
+                sources = makeAudioSources()
+            }
+        }
+    }
+
+    func setUp() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            // If you set the "mode" parameter, stereo capture is not possible, so it is left unspecified.
+            try session.setCategory(.playAndRecord, mode: .videoRecording, options: [.defaultToSpeaker, .allowBluetooth])
+            // It looks like this setting is required on iOS 18.5.
+            try session.setPreferredInputNumberOfChannels(2)
+            try session.setActive(true)
+        } catch {
+            logger.error(error)
+        }
+    }
+
+    func sourcesUpdates() -> AsyncStream<[AudioSource]> {
+        AsyncStream { continuation in
+            self.continuation = continuation
+            continuation.yield(sources)
+        }
+    }
+
+    func selectAudioSource(_ audioSource: AudioSource) throws {
+        setPreferredInputBuiltInMic(true)
+        guard let preferredInput = AVAudioSession.sharedInstance().preferredInput,
+              let dataSources = preferredInput.dataSources,
+              let newDataSource = dataSources.first(where: { $0.dataSourceName == audioSource.dataSourceName }),
+              let supportedPolarPatterns = newDataSource.supportedPolarPatterns else {
+            throw Error.missingDataSource(audioSource)
+        }
+        do {
+            let isStereoSupported = supportedPolarPatterns.contains(.stereo)
+            if isStereoSupported {
+                try newDataSource.setPreferredPolarPattern(.stereo)
+            }
+            try preferredInput.setPreferredDataSource(newDataSource)
+        } catch {
+            logger.warn(error)
+        }
+    }
+
+    private func makeAudioSources() -> [AudioSource] {
+        if session.inputDataSources?.isEmpty == true {
+            setPreferredInputBuiltInMic(false)
+        } else {
+            setPreferredInputBuiltInMic(true)
+        }
+        guard let preferredInput = session.preferredInput else {
+            return []
+        }
+        var sources: [AudioSource] = []
+        for dataSource in session.preferredInput?.dataSources ?? [] {
+            sources.append(.init(
+                portName: preferredInput.portName,
+                dataSourceName: dataSource.dataSourceName,
+                isSupportedStereo: dataSource.supportedPolarPatterns?.contains(.stereo) ?? false
+            ))
+        }
+        return sources
+    }
+
+    private func setPreferredInputBuiltInMic(_ isEnabled: Bool) {
+        do {
+            if isEnabled {
+                guard let availableInputs = session.availableInputs,
+                      let builtInMicInput = availableInputs.first(where: { $0.portType == .builtInMic }) else {
+                    return
+                }
+                try session.setPreferredInput(builtInMicInput)
+            } else {
+                try session.setPreferredInput(nil)
+            }
+        } catch {
+            logger.warn(error)
+        }
+    }
+}

--- a/Examples/iOS/IngestView.swift
+++ b/Examples/iOS/IngestView.swift
@@ -49,6 +49,16 @@ struct IngestView: View {
             }
             VStack(alignment: .trailing) {
                 HStack(spacing: 16) {
+                    if !model.audioSources.isEmpty {
+                        Picker("AudioSource", selection: $model.audioSource) {
+                            ForEach(model.audioSources, id: \.description) { source in
+                                Text(source.description).tag(source)
+                            }
+                        }
+                        .background(Color.black.opacity(0.2))
+                        .cornerRadius(16)
+                        .padding(16)
+                    }
                     Spacer()
                     Button(action: { Task {
                         model.flipCamera()
@@ -137,14 +147,6 @@ struct IngestView: View {
             }
         }
         .onAppear {
-            let session = AVAudioSession.sharedInstance()
-            do {
-                // If you set the "mode" parameter, stereo capture is not possible, so it is left unspecified.
-                try session.setCategory(.playAndRecord, options: [.defaultToSpeaker, .allowBluetooth])
-                try session.setActive(true)
-            } catch {
-                logger.error(error)
-            }
             model.startRunning(preference)
         }
         .onDisappear {


### PR DESCRIPTION
## Description & motivation
- The stereo streaming example was not working, so I rewrote it as the 2025 edition.
- The key points to make it work are as follows:

1. Configure AVAudioSession as shown below.
https://github.com/HaishinKit/HaishinKit.swift/blob/5a48dbd7fe60dfcde0dd4b88c0c7292f7ba27d10/Examples/iOS/AudioSourceService.swift#L57-L61
1. Set the following values in MediaMixer.
https://github.com/HaishinKit/HaishinKit.swift/blob/5a48dbd7fe60dfcde0dd4b88c0c7292f7ba27d10/Examples/iOS/IngestViewModel.swift#L113-L116
1. Refer to the code in the PR below for the stereo source.
https://github.com/HaishinKit/HaishinKit.swift/blob/5a48dbd7fe60dfcde0dd4b88c0c7292f7ba27d10/Examples/iOS/AudioSourceService.swift#L74-L93

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:
