### PR TITLE
Fixed an issue where the properties of AudioMixerTrackSettings were unintentionally applied to AVAudioConverter each time.

### DIFF
--- a/Examples/iOS/PublishView.swift
+++ b/Examples/iOS/PublishView.swift
@@ -77,6 +77,17 @@ struct PublishView: View {
                             .frame(width: 30, height: 30)
                     })
                     Button(action: {
+                        model.toggleAudioMuted()
+                    }, label: {
+                        Image(systemName: model.isAudioMuted ?
+                                "microphone.slash.circle" :
+                                "microphone.circle")
+                            .resizable()
+                            .scaledToFit()
+                            .foregroundColor(.white)
+                            .frame(width: 30, height: 30)
+                    })
+                    Button(action: {
                         model.flipCamera()
                     }, label: {
                         Image(systemName:

--- a/Examples/iOS/PublishViewModel.swift
+++ b/Examples/iOS/PublishViewModel.swift
@@ -16,6 +16,7 @@ final class PublishViewModel: ObservableObject {
         }
     }
     @Published var isShowError = false
+    @Published private(set) var isAudioMuted = false
     @Published private(set) var isTorchEnabled = false
     @Published private(set) var readyState: SessionReadyState = .closed
     @Published var audioSource: AudioSource = .empty {
@@ -123,6 +124,26 @@ final class PublishViewModel: ObservableObject {
                     }
                     break
                 }
+            }
+        }
+    }
+
+    func toggleAudioMuted() {
+        Task {
+            if isAudioMuted {
+                var settings = await mixer.audioMixerSettings
+                var track = settings.tracks[0] ?? .init()
+                track.isMuted = false
+                settings.tracks[0] = track
+                await mixer.setAudioMixerSettings(settings)
+                isAudioMuted = false
+            } else {
+                var settings = await mixer.audioMixerSettings
+                var track = settings.tracks[0] ?? .init()
+                track.isMuted = true
+                settings.tracks[0] = track
+                await mixer.setAudioMixerSettings(settings)
+                isAudioMuted = true
             }
         }
     }

--- a/HaishinKit/Sources/Mixer/AudioMixerTrack.swift
+++ b/HaishinKit/Sources/Mixer/AudioMixerTrack.swift
@@ -1,86 +1,22 @@
 import Accelerate
 import AVFoundation
 
-private let kIOAudioMixerTrack_frameCapacity: AVAudioFrameCount = 1024
+private let kAudioMixerTrack_frameCapacity: AVAudioFrameCount = 1024
 
 protocol AudioMixerTrackDelegate: AnyObject {
     func track(_ track: AudioMixerTrack<Self>, didOutput audioPCMBuffer: AVAudioPCMBuffer, when: AVAudioTime)
     func track(_ track: AudioMixerTrack<Self>, errorOccurred error: AudioMixerError)
 }
 
-/// Constraints on the audio mixier track's settings.
-public struct AudioMixerTrackSettings: Codable, Sendable {
-    /// The default value.
-    public static let `default` = AudioMixerTrackSettings()
-
-    /// Specifies the volume for output.
-    public var volume: Float
-
-    /// Specifies the muted that indicates whether the audio output is muted.
-    public var isMuted = false
-
-    /// Specifies the mixes the channels or not. Currently, it supports input sources with 4, 5, 6, and 8 channels.
-    public var downmix = true
-
-    /// Specifies the map of the output to input channels.
-    /// ## Example code:
-    /// ```
-    /// // If you want to use the 3rd and 4th channels from a 4-channel input source for a 2-channel output, you would specify it like this.
-    /// channelMap = [2, 3]
-    /// ```
-    public var channelMap: [Int]?
-
-    /// Creates a new instance.
-    public init(volume: Float = 1.0, isMuted: Bool = false, downmix: Bool = true, channelMap: [Int]? = nil) {
-        self.volume = volume
-        self.isMuted = isMuted
-        self.downmix = downmix
-        self.channelMap = channelMap
-    }
-
-    func apply(_ converter: AVAudioConverter?, oldValue: AudioMixerTrackSettings?) {
-        guard let converter else {
-            return
-        }
-        if converter.downmix != downmix {
-            converter.downmix = downmix
-        }
-        if let channelMap = validatedChannelMap(converter) {
-            converter.channelMap = channelMap.map { NSNumber(value: $0) }
-        } else {
-            switch converter.outputFormat.channelCount {
-            case 1:
-                converter.channelMap = [0]
-            case 2:
-                converter.channelMap = (converter.inputFormat.channelCount == 1) ? [0, 0] : [0, 1]
-            default:
-                break
-            }
-        }
-    }
-
-    private func validatedChannelMap(_ converter: AVAudioConverter) -> [Int]? {
-        guard let channelMap, channelMap.count == converter.outputFormat.channelCount else {
-            return nil
-        }
-        for inputChannel in channelMap where converter.inputFormat.channelCount <= inputChannel {
-            return nil
-        }
-        return channelMap
-    }
-}
-
 final class AudioMixerTrack<T: AudioMixerTrackDelegate> {
     let id: UInt8
     let outputFormat: AVAudioFormat
-
+    weak var delegate: T?
     var settings: AudioMixerTrackSettings = .init() {
         didSet {
             settings.apply(audioConverter, oldValue: oldValue)
         }
     }
-    weak var delegate: T?
-
     var inputFormat: AVAudioFormat? {
         return audioConverter?.inputFormat
     }
@@ -101,7 +37,19 @@ final class AudioMixerTrack<T: AudioMixerTrackDelegate> {
             guard let audioConverter else {
                 return
             }
-            settings.apply(audioConverter, oldValue: nil)
+            audioConverter.downmix = settings.downmix
+            if let channelMap = settings.validatedChannelMap(audioConverter) {
+                audioConverter.channelMap = channelMap.map { NSNumber(value: $0) }
+            } else {
+                switch audioConverter.outputFormat.channelCount {
+                case 1:
+                    audioConverter.channelMap = [0]
+                case 2:
+                    audioConverter.channelMap = (audioConverter.inputFormat.channelCount == 1) ? [0, 0] : [0, 1]
+                default:
+                    break
+                }
+            }
             audioConverter.primeMethod = .normal
         }
     }
@@ -167,9 +115,9 @@ final class AudioMixerTrack<T: AudioMixerTrackDelegate> {
             delegate?.track(self, errorOccurred: .failedToCreate(from: inputFormat, to: outputFormat))
             return
         }
-        inputBuffer = .init(pcmFormat: inputFormat, frameCapacity: 1024 * 4)
         ringBuffer = .init(inputFormat)
-        outputBuffer = .init(pcmFormat: outputFormat, frameCapacity: kIOAudioMixerTrack_frameCapacity)
+        inputBuffer = .init(pcmFormat: inputFormat, frameCapacity: kAudioMixerTrack_frameCapacity * 4)
+        outputBuffer = .init(pcmFormat: outputFormat, frameCapacity: kAudioMixerTrack_frameCapacity)
         if logger.isEnabledFor(level: .info) {
             logger.info("inputFormat:", inputFormat, ", outputFormat:", outputFormat)
         }

--- a/HaishinKit/Sources/Mixer/AudioMixerTrackSettings.swift
+++ b/HaishinKit/Sources/Mixer/AudioMixerTrackSettings.swift
@@ -1,0 +1,56 @@
+import AVFoundation
+
+/// Constraints on the audio mixier track's settings.
+public struct AudioMixerTrackSettings: Codable, Sendable {
+    /// The default value.
+    public static let `default` = AudioMixerTrackSettings()
+
+    /// Specifies the volume for output.
+    public var volume: Float
+
+    /// Specifies the muted that indicates whether the audio output is muted.
+    public var isMuted = false
+
+    /// Specifies the mixes the channels or not. Currently, it supports input sources with 4, 5, 6, and 8 channels.
+    public var downmix = true
+
+    /// Specifies the map of the output to input channels.
+    /// ## Example code:
+    /// ```swift
+    /// // If you want to use the 3rd and 4th channels from a 4-channel input source for a 2-channel output, you would specify it like this.
+    /// channelMap = [2, 3]
+    /// ```
+    public var channelMap: [Int]?
+
+    /// Creates a new instance.
+    public init(volume: Float = 1.0, isMuted: Bool = false, downmix: Bool = true, channelMap: [Int]? = nil) {
+        self.volume = volume
+        self.isMuted = isMuted
+        self.downmix = downmix
+        self.channelMap = channelMap
+    }
+
+    func apply(_ converter: AVAudioConverter?, oldValue: AudioMixerTrackSettings) {
+        guard let converter else {
+            return
+        }
+        if downmix != oldValue.downmix {
+            converter.downmix = downmix
+        }
+        if channelMap != oldValue.channelMap {
+            if let channelMap = validatedChannelMap(converter) {
+                converter.channelMap = channelMap.map { NSNumber(value: $0) }
+            }
+        }
+    }
+
+    func validatedChannelMap(_ converter: AVAudioConverter) -> [Int]? {
+        guard let channelMap, channelMap.count == converter.outputFormat.channelCount else {
+            return nil
+        }
+        for inputChannel in channelMap where converter.inputFormat.channelCount <= inputChannel {
+            return nil
+        }
+        return channelMap
+    }
+}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- Fixed an issue where writing code like the following caused properties such as `downmix` and `channelMap` of AVAudioConverter to be set repeatedly.
  - https://github.com/HaishinKit/HaishinKit.swift/discussions/1818#discussioncomment-14720555
- There was a possibility that unintended property changes in `AVAudioConverter` could have caused issues.
   ```swift
   Task {
       var audioSetting = await mixer.audioMixerSettings
       if let firstTrack = audioSetting.tracks[0] {
           isMuted = !firstTrack.isMuted
           audioSetting.tracks[0]?.isMuted = isMuted
       }
       await mixer.setAudioMixerSettings(audioSetting)
   }
   ```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:
