### PR TITLE
Made expectedFrameRate optional.

### DIFF
--- a/Examples/Preference.swift
+++ b/Examples/Preference.swift
@@ -5,7 +5,7 @@ struct Preference: Sendable {
     static nonisolated(unsafe) var `default` = Preference()
 
     // var uri = "http://192.168.1.14:1985/rtc/v1/whip/?app=live&stream=livestream"
-    var uri = "rtmp://192.168.1.17/live"
+    var uri = "rtmp://192.168.1.11/live"
     var streamName = "live"
 
     func makeURL() -> URL? {

--- a/Examples/iOS/PublishViewModel.swift
+++ b/Examples/iOS/PublishViewModel.swift
@@ -355,6 +355,10 @@ final class PublishViewModel: ObservableObject {
                 }
                 // Sets to output frameRate.
                 try await mixer.setFrameRate(fps)
+                if var videoSettings = await session?.stream.videoSettings {
+                    videoSettings.expectedFrameRate = fps
+                    try? await session?.stream.setVideoSettings(videoSettings)
+                }
             } catch {
                 logger.error(error)
             }

--- a/HaishinKit/Sources/Codec/VTSessionMode.swift
+++ b/HaishinKit/Sources/Codec/VTSessionMode.swift
@@ -32,6 +32,9 @@ enum VTSessionMode {
             guard status == noErr else {
                 throw VTSessionError.failedToPrepare(status: status)
             }
+            if let expectedFrameRate = videoCodec.settings.expectedFrameRate {
+                status = session.setOption(.init(key: .expectedFrameRate, value: expectedFrameRate as CFNumber))
+            }
             videoCodec.frameInterval = videoCodec.settings.frameInterval
             return session
         case .decompression:

--- a/RTMPHaishinKit/Sources/RTMP/RTMPStream.swift
+++ b/RTMPHaishinKit/Sources/RTMP/RTMPStream.swift
@@ -692,7 +692,9 @@ public actor RTMPStream {
             metadata["height"] = outgoing.videoSettings.videoSize.height
             metadata["videocodecid"] = outgoing.videoSettings.format.codecid
             metadata["videodatarate"] = outgoing.videoSettings.bitRate / 1000
-            metadata["framerate"] = outgoing.videoSettings.expectedFrameRate
+            if let expectedFrameRate = outgoing.videoSettings.expectedFrameRate {
+                metadata["framerate"] = outgoing.videoSettings.expectedFrameRate
+            }
         }
         if let audioFormat = outgoing.audioInputFormat?.audioStreamBasicDescription {
             metadata["audiocodecid"] = outgoing.audioSettings.format.codecid


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- Since the 2.0 release, there hasn’t been any way to set it.
- It seems preferable to specify it, but not mandatory, so we will treat it as optional.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:
