### PR TITLE
Fix: Reflects the actual capture state.

### DIFF
--- a/HaishinKit/Sources/Mixer/CaptureSession.swift
+++ b/HaishinKit/Sources/Mixer/CaptureSession.swift
@@ -6,6 +6,7 @@ protocol CaptureSessionConvertible: Runner {
     var sessionPreset: AVCaptureSession.Preset { get set }
     #endif
 
+    var isCapturing: Bool { get }
     var isInturreped: AsyncStream<Bool> { get }
     var runtimeError: AsyncStream<AVError> { get }
     var synchronizationClock: CMClock? { get }
@@ -35,7 +36,9 @@ final class CaptureSession {
         }
     }
 
-    private(set) var isRunning = false
+    var isCapturing: Bool {
+        session.isRunning
+    }
 
     var isMultitaskingCameraAccessEnabled: Bool {
         capabilities.isMultitaskingCameraAccessEnabled(session)
@@ -50,6 +53,8 @@ final class CaptureSession {
     var synchronizationClock: CMClock? {
         capabilities.synchronizationClock(session)
     }
+
+    private(set) var isRunning = false
 
     #if !os(visionOS)
     var sessionPreset: AVCaptureSession.Preset = .default {
@@ -86,7 +91,13 @@ final class CaptureSession {
         }
     }
 
-    private(set) var isRunning = false
+    var isCapturing: Bool {
+        if #available(tvOS 17.0, *) {
+            session.isRunning
+        } else {
+            false
+        }
+    }
 
     var isMultitaskingCameraAccessEnabled: Bool {
         if #available(tvOS 17.0, *) {
@@ -109,6 +120,8 @@ final class CaptureSession {
             return nil
         }
     }
+
+    private(set) var isRunning = false
 
     private var _session: Any?
     /// The capture session instance.
@@ -304,6 +317,7 @@ final class NullCaptureSession: CaptureSessionConvertible {
     }
     #endif
 
+    let isCapturing: Bool = false
     var isMultiCamSessionEnabled = false
     let isMultitaskingCameraAccessEnabled = false
     let synchronizationClock: CMClock? = nil

--- a/HaishinKit/Sources/Mixer/MediaMixer.swift
+++ b/HaishinKit/Sources/Mixer/MediaMixer.swift
@@ -104,10 +104,10 @@ public final actor MediaMixer {
     /// The output frame rate.
     public private(set) var frameRate = MediaMixer.defaultFrameRate
 
-    /// The capture session is in a running state or not.
+    /// The AVCaptureSession is in a running state or not.
     @available(tvOS 17.0, *)
     public var isCapturing: Bool {
-        session.isRunning
+        session.isCapturing
     }
 
     /// The interrupts events is occured or not.
@@ -311,6 +311,7 @@ public final actor MediaMixer {
     @available(tvOS 17.0, *)
     public func startCapturing() {
         guard !session.isRunning else {
+            session.startRunningIfNeeded()
             return
         }
         session.startRunning()


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- MediaMixer.isCapturing so that it now uses the actual AVCaptureSession.isRunning value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:
