### PR TITLE
fix a crash caused by an AudioRingBuffer buffer overrun

### DIFF
--- a/HaishinKit/Sources/Mixer/AudioRingBuffer.swift
+++ b/HaishinKit/Sources/Mixer/AudioRingBuffer.swift
@@ -54,6 +54,10 @@ final class AudioRingBuffer {
         if sampleTime == 0 {
             sampleTime = targetSampleTime
         }
+        if outputBuffer.frameLength < sampleBuffer.numSamples {
+            skip += sampleBuffer.numSamples
+            return
+        }
         if inputBuffer.frameLength < sampleBuffer.numSamples {
             if let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: AVAudioFrameCount(sampleBuffer.numSamples)) {
                 self.inputBuffer = buffer
@@ -103,7 +107,7 @@ final class AudioRingBuffer {
         if 0 < skip {
             let numSamples = min(Int(inNumberFrames), skip)
             guard let bufferList = UnsafeMutableAudioBufferListPointer(ioData) else {
-                return noErr
+                return -1
             }
             if inputFormat.isInterleaved {
                 let channelCount = Int(inputFormat.channelCount)
@@ -139,7 +143,7 @@ final class AudioRingBuffer {
         }
         let numSamples = min(Int(inNumberFrames), Int(outputBuffer.frameLength) - tail)
         guard let bufferList = UnsafeMutableAudioBufferListPointer(ioData), head != tail else {
-            return noErr
+            return -1
         }
         if inputFormat.isInterleaved {
             let channelCount = Int(inputFormat.channelCount)

--- a/HaishinKit/Tests/Mixer/AudioRingBufferTests.swift
+++ b/HaishinKit/Tests/Mixer/AudioRingBufferTests.swift
@@ -13,6 +13,39 @@ import Testing
         try appendSampleBuffer(1024, channels: 1)
     }
 
+    @Test func monoAppendSampleBuffer_overrun() throws {
+        let numSamples = 1024 * 4
+        var asbd = AudioStreamBasicDescription(
+            mSampleRate: 44100,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: 0xc,
+            mBytesPerPacket: 2,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: 2,
+            mChannelsPerFrame: 1,
+            mBitsPerChannel: 16,
+            mReserved: 0
+        )
+        let format = AVAudioFormat(streamDescription: &asbd)
+        let buffer = AudioRingBuffer(format!, bufferCounts: 3) // 1024 * 3
+        guard
+            let readBuffer = AVAudioPCMBuffer(pcmFormat: AVAudioFormat(streamDescription: &asbd)!, frameCapacity: AVAudioFrameCount(1024)),
+            let sinWave = CMAudioSampleBufferFactory.makeSinWave(44100, numSamples: numSamples, channels: 1) else {
+            return
+        }
+        buffer?.append(sinWave)
+        #expect(buffer?.isDataAvailable(1024) == true)
+        #expect(buffer?.render(UInt32(1024), ioData: readBuffer.mutableAudioBufferList) == noErr)
+        #expect(buffer?.isDataAvailable(1024) == true)
+        #expect(buffer?.render(UInt32(1024), ioData: readBuffer.mutableAudioBufferList) == noErr)
+        #expect(buffer?.isDataAvailable(1024) == true)
+        #expect(buffer?.render(UInt32(1024), ioData: readBuffer.mutableAudioBufferList) == noErr)
+        #expect(buffer?.isDataAvailable(1024) == true)
+        #expect(buffer?.render(UInt32(1024), ioData: readBuffer.mutableAudioBufferList) == noErr)
+        #expect(buffer?.isDataAvailable(1024) == false)
+        #expect(buffer?.render(UInt32(1024), ioData: readBuffer.mutableAudioBufferList) != noErr)
+    }
+
     @Test func stereoAppendSampleBuffer_920() throws {
         try appendSampleBuffer(920, channels: 2)
     }
@@ -45,7 +78,7 @@ import Testing
         for _ in 0..<30 {
             buffer?.append(sinWave)
             readBuffer.int16ChannelData?[0].update(repeating: 0, count: numSamples)
-            _ = buffer?.render(UInt32(numSamples), ioData: readBuffer.mutableAudioBufferList)
+            #expect(buffer?.render(UInt32(numSamples), ioData: readBuffer.mutableAudioBufferList) == noErr)
             #expect(try sinWave.dataBuffer?.dataBytes().bytes == Data(bytes: bufferList[0].mData!, count: numSamples * Int(channels) * 2).bytes)
         }
     }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
Fix a crash caused by an AudioRingBuffer buffer overrun
- refs https://github.com/HaishinKit/HaishinKit.swift/pull/1864

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:
