### PR TITLE
Fix Swift 6 data race: Sending 'iterator' risks causing data races in RTMPConnection

### DIFF
--- a/RTMPHaishinKit/Sources/RTMP/RTMPConnection.swift
+++ b/RTMPHaishinKit/Sources/RTMP/RTMPConnection.swift
@@ -435,9 +435,9 @@ public actor RTMPConnection: HaishinKit.NetworkConnection {
         if logger.isEnabledFor(level: .trace) {
             logger.trace("<<", message)
         }
-        let iterator = outputBuffer.putMessage(type, chunkStreamId: chunkStreamId.rawValue, message: message)
+        let chunks = Array(outputBuffer.putMessage(type, chunkStreamId: chunkStreamId.rawValue, message: message))
         Task {
-            await socket?.send(iterator)
+            await socket?.send(chunks)
         }
         return message.payload.count
     }

--- a/RTMPHaishinKit/Sources/RTMP/RTMPSocket.swift
+++ b/RTMPHaishinKit/Sources/RTMP/RTMPSocket.swift
@@ -101,6 +101,16 @@ final actor RTMPSocket {
         }
     }
 
+    func send(_ chunks: [Data]) {
+        guard connected else {
+            return
+        }
+        for data in chunks {
+            queueBytesOut += data.count
+            outputs?.yield(data)
+        }
+    }
+
     func recv() -> AsyncStream<Data> {
         AsyncStream<Data> { continuation in
             Task {


### PR DESCRIPTION
## Problem
`AnyIterator<Data>` is not `Sendable`, so capturing it in a `Task {}` closure and sending it into the `RTMPSocket` actor causes a Swift 6 strict concurrency build error (Xcode 26).

## Fix
- Materialise the iterator into `[Data]` (which is `Sendable`) before the `Task` boundary in `RTMPConnection.doOutput()`
- Add a `send(_ chunks: [Data])` overload to `RTMPSocket` so the actor receives a Sendable value in a single hop

Semantics are identical — all chunks sent in the same order.

Fixes #1895